### PR TITLE
Freeze rust version to 1.83

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -22,6 +22,7 @@ on:
         type: string
 env:
     CARGO_TERM_COLOR: always
+    rust_version: 1.83.0
 jobs:
   build:
     runs-on: ${{ inputs.os }}
@@ -29,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: versions
         run: |
+          rustup default ${{ env.rust_version }}
           rustup --version
           cargo --version
           rustc --version


### PR DESCRIPTION
Internal repo checks need a more static rust version, so to remain consistent let's freeze this one and update as necessary

Signed-off-by: Jonatan Waern <jonatanwaern@intel.com>
