### PR TITLE
Reduce workflow permissions further

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,7 +1,6 @@
 name: Build Binaries
 
-permissions:
-  actions: write
+permissions: read-all
 
 on:
   workflow_call:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
       branches: [ "main" ]
   pull_request:
       branches: [ "main" ]
+  workflow_dispatch:
   schedule:
       - cron: "0 0 * * *"
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,6 @@
 name: Archive Binary
 
-permissions:
-  actions: write
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -1,7 +1,6 @@
 name: Cargo Check
 
-permissions:
-  actions: write
+permissions: read-all
 
 on:
   workflow_call:


### PR DESCRIPTION
It is unclear whether upload-artifact actually does require write permissions, there does not seem to be any official documentation on this that I can find (the github API does not directly expose upload-artifact, rather it is only available through custom actions). However, it would seem incredibly strange to me that write permissions would _not_ be needed.
