### PR TITLE
Avoid crash when a non-arrayed declaration conflicts with an arrayed one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 -->
 # Change Log
 
+## 0.9.7
+- Fixed DLS crash that occured when an object was declarated both with array dimensions and without
+
 ## 0.9.6
 - Added DFA command-line-option "--suppress-imports" which makes the server not recurse analysis into imported files
 

--- a/src/analysis/templating/objects.rs
+++ b/src/analysis/templating/objects.rs
@@ -1689,8 +1689,16 @@ fn merge_composite_subobj<'c>(name: String,
         .map(|d|(d.clone(), vec![])).collect();
     for (decl, _) in &specs {
         if decl.obj.dims.len() != array_info.len() {
+            // When an object with no array decl conflicts with an object
+            // with one, blame the object decl
+            let error_span = if !decl.obj.dims.is_empty() {
+                combine_vec_of_decls(&decl.obj.dims)
+            } else {
+                *decl.obj.span()
+            };
+
             report.push(DMLError {
-                span: combine_vec_of_decls(&decl.obj.dims),
+                span: error_span,
                 description: "Mismatching number of dimensions \
                               in object declaration".to_string(),
                 related: vec![(combine_vec_of_decls(&auth_obj.obj.dims),


### PR DESCRIPTION
Signed-off-by: Jonatan Waern (jonatan.waern@intel.com)
