### PR TITLE
Improve feedback to user when information is knowably incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 -- When requesting symbol information about types
 -- When requesting symbol or reference information about symbols or references from
    inside an uninstantiated template
+- Fine-grained the 'showWarnings' setting, can now be set to 'once', 'always',
+  or 'never'
 
 ## 0.9.8
 - Correct behavior of DFA "-t" flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## 0.9.9
 - Added "warning" as a valid log statement type.
+- Added warning feedback through LSP messages when analysis might be unavailable
+  or only partially complete
+-- When isolated/device (also known as syntactic/semantic) analysis is not available
+-- When requesting symbol information about types
+-- When requesting symbol or reference information about symbols or references from
+   inside an uninstantiated template
 
 ## 0.9.8
 - Correct behavior of DFA "-t" flag

--- a/src/actions/analysis_queue.rs
+++ b/src/actions/analysis_queue.rs
@@ -389,8 +389,9 @@ impl DeviceAnalysisJob {
 
         trace!("Bases are {:?}", bases.iter().collect::<Vec<&CanonPath>>());
         let root_analysis = analysis.get_isolated_analysis(root)
-            .ok_or_else(
-                ||"Failed to get root isolated analysis".to_string())?.clone();
+            .map_err(
+                // NOTE/TODO: Could sanity that we fail in an expected way here
+                |_|"Failed to get root isolated analysis".to_string())?.clone();
         let (bases, missing) : (Vec<TimestampedStorage<IsolatedAnalysis>>,
                                 HashSet<CanonPath>) =
             bases.iter().map(|p|(p, analysis.isolated_analysis.get(p).cloned()))
@@ -474,7 +475,7 @@ impl LinterJob {
         let mut hasher = DefaultHasher::new();
         Hash::hash(&device, &mut hasher);
         let hash = hasher.finish();
-        if let Some(isolated_analysis) = analysis.get_isolated_analysis(&device) {
+        if let Ok(isolated_analysis) = analysis.get_isolated_analysis(&device) {
             Ok(LinterJob {
                 file: device.to_owned(),
                 timestamp,

--- a/src/actions/analysis_storage.rs
+++ b/src/actions/analysis_storage.rs
@@ -517,7 +517,7 @@ impl AnalysisStorage {
                self.device_analysis.keys().collect::<Vec<&CanonPath>>());
     }
 
-    pub fn get_linter_analysis<'a>(&'a mut self, path: &Path)
+    pub fn get_linter_analysis<'a>(&'a self, path: &Path)
                                      -> Option<&'a LinterAnalysis> {
         trace!("Looking for linter analysis of {:?}", path);
         let analysis = self.lint_analysis.get(
@@ -692,8 +692,7 @@ impl AnalysisStorage {
         notifier.notify_end_diagnostics();
     }
 
-    pub fn gather_linter_errors(&mut self,
-                               path: &CanonPath) -> Vec<DMLError> {
+    pub fn gather_linter_errors(&self, path: &CanonPath) -> Vec<DMLError> {
         if let Some(linter_analysis) = self.get_linter_analysis(path) {
             linter_analysis.errors.clone()
         } else {

--- a/src/actions/analysis_storage.rs
+++ b/src/actions/analysis_storage.rs
@@ -517,11 +517,10 @@ impl AnalysisStorage {
                self.device_analysis.keys().collect::<Vec<&CanonPath>>());
     }
 
-    pub fn get_linter_analysis<'a>(&'a self, path: &Path)
+    pub fn get_linter_analysis<'a>(&'a self, path: &CanonPath)
                                      -> Option<&'a LinterAnalysis> {
         trace!("Looking for linter analysis of {:?}", path);
-        let analysis = self.lint_analysis.get(
-            &CanonPath::from_path_buf(path.to_path_buf())?).map(
+        let analysis = self.lint_analysis.get(path).map(
             |storage|&storage.stored);
         if analysis.is_none() {
             trace!("Failed to find linter analysis");

--- a/src/actions/analysis_storage.rs
+++ b/src/actions/analysis_storage.rs
@@ -22,7 +22,6 @@ use crate::lsp_data::*;
 use crate::analysis::parsing::tree::{ZeroSpan, ZeroFilePosition};
 use crate::analysis::reference::Reference;
 use crate::server::{Output, ServerToHandle};
-use crate::Span;
 
 use crate::lint::LinterAnalysis;
 
@@ -710,30 +709,5 @@ impl AnalysisStorage {
                                 -> HashMap<PathBuf, Vec<DMLError>> {
         self.get_device_analysis(path).map_or(HashMap::default(),
                                               |a|a.errors.clone())
-    }
-
-    pub fn errors(&mut self, span: &Span) -> Vec<DMLError> {
-        trace!("Reporting errors at {:?} for {:?}", span.range, span.file);
-        let real_file = if let Some(file) = CanonPath::from_path_buf(
-            span.path()) {
-            file
-        } else {
-            error!("Could not resolve {:?} to point to a real file", span);
-            return vec![];
-        };
-        if let Some(isolated_analysis) =
-            self.get_isolated_analysis(&real_file) {
-            // Obtain any error which at least partially overlaps our span
-            let mut errors = vec![];
-            for error in &isolated_analysis.errors {
-                if error.span.range.overlaps(span.range) {
-                    errors.push(error.clone())
-                }
-            }
-            errors
-        } else {
-            trace!("lacked analysis");
-            vec![]
-        }
     }
 }

--- a/src/actions/analysis_storage.rs
+++ b/src/actions/analysis_storage.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, SystemTime};
 
 use crate::actions::progress::{DiagnosticsNotifier,
                                AnalysisDiagnosticsNotifier};
-use crate::analysis::scope::ContextedSymbol;
+use crate::analysis::scope::{ContextedSymbol, ContextKey};
 use crate::analysis::structure::objects::Import;
 use crate::analysis::{IsolatedAnalysis, DeviceAnalysis, DMLError};
 
@@ -212,7 +212,15 @@ impl AnalysisStorage {
                 .ok_or(AnalysisLookupError::NoFile)?;
             let analysis = self.get_isolated_analysis(&canon_path)?;
             Ok(analysis.lookup_reference(pos))
-    }
+        }
+
+    pub fn first_context_at_pos(&self, pos: &ZeroFilePosition) ->
+        Result<Option<ContextKey>, AnalysisLookupError> {
+            let canon_path = CanonPath::from_path_buf(pos.path())
+                .ok_or(AnalysisLookupError::NoFile)?;
+            let analysis = self.get_isolated_analysis(&canon_path)?;
+            Ok(analysis.lookup_first_context(pos))
+        }
 
     pub fn has_client_file(&self, path: &Path) -> bool {
         self.isolated_analysis.keys().any(

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -18,6 +18,7 @@ use std::sync::{Arc, Mutex};
 use crate::actions::analysis_storage::AnalysisStorage;
 use crate::actions::analysis_queue::AnalysisQueue;
 use crate::actions::progress::{AnalysisProgressNotifier, ProgressNotifier};
+use crate::analysis::DLSLimitation;
 use crate::analysis::structure::expressions::Expression;
 use crate::concurrency::{Jobs, ConcurrentJob};
 use crate::config::Config;
@@ -183,6 +184,7 @@ pub struct InitActionContext {
 
     pub config: Arc<Mutex<Config>>,
     pub lint_config: Arc<Mutex<LintCfg>>,
+    pub sent_warnings: Arc<Mutex<HashSet<DLSLimitation>>>,
     jobs: Arc<Mutex<Jobs>>,
     pub client_capabilities: Arc<lsp_data::ClientCapabilities>,
     pub has_notified_missing_builtins: bool,
@@ -242,6 +244,7 @@ impl InitActionContext {
             pid,
             workspace_roots: Arc::default(),
             compilation_info: Arc::default(),
+            sent_warnings: Arc::default(),
         }
     }
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -85,7 +85,7 @@ const EXAMPLE: DLSLimitation =
         description: "Example of a DLS limitation",
     };
 
-#[derive(Debug, Eq, PartialEq, Hash,)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash,)]
 pub struct DLSLimitation {
     pub issue_num: u64,
     pub description: &'static str,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -78,6 +78,25 @@ pub struct FileSpec<'a> {
 pub const IMPLICIT_IMPORTS: [&str; 2] = ["dml-builtins.dml",
                                          "simics/device-api.dml"];
 
+#[allow(dead_code)]
+const EXAMPLE: DLSLimitation =
+    DLSLimitation {
+        issue_num: 42,
+        description: "Example of a DLS limitation",
+    };
+
+#[derive(Debug, Eq, PartialEq, Hash,)]
+pub struct DLSLimitation {
+    pub issue_num: u64,
+    pub description: &'static str,
+}
+
+impl fmt::Display for DLSLimitation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (issue#{})", self.description, self.issue_num)
+    }
+}
+
 fn collapse_referencematches<T>(matches: T) -> ReferenceMatch
 where T : IntoIterator<Item = ReferenceMatch> {
     matches.into_iter().fold(
@@ -921,9 +940,11 @@ impl DeviceAnalysis {
         }
     }
 
-    pub fn lookup_symbols_by_contexted_symbol<'t>(&self,
-                                                  sym: &ContextedSymbol<'t>)
-                                                  -> Vec<SymbolRef> {
+    pub fn lookup_symbols_by_contexted_symbol<'t>(
+        &self,
+        sym: &ContextedSymbol<'t>,
+        _limitations: &mut HashSet<DLSLimitation>)
+        -> Vec<SymbolRef> {
         if matches!(sym.symbol.kind, DMLSymbolKind::Template |
                     DMLSymbolKind::Typedef | DMLSymbolKind::Extern)
         {

--- a/src/analysis/parsing/types.rs
+++ b/src/analysis/parsing/types.rs
@@ -11,7 +11,8 @@ use crate::analysis::parsing::tree::{AstObject, TreeElement, TreeElements,
                             LeafToken, ZeroRange};
 use crate::analysis::parsing::misc::{CDecl, ident_filter};
 use crate::analysis::parsing::expression::Expression;
-use crate::analysis::LocalDMLError;
+use crate::analysis::reference::{Reference, ReferenceKind};
+use crate::analysis::{FileSpec, LocalDMLError};
 use crate::vfs::TextFile;
 
 pub fn typeident_filter(token: TokenKind) -> bool {
@@ -467,6 +468,18 @@ pub enum BaseTypeContent {
 }
 
 impl TreeElement for BaseTypeContent {
+    fn references<'a>(&self,
+                      accumulator: &mut Vec<Reference>,
+                      file: FileSpec<'a>) {
+        self.default_references(accumulator, file);
+        if let BaseTypeContent::Ident(leaf) = self {
+            if let Some(refr) = Reference::global_from_token(
+                leaf, file, ReferenceKind::Type) {
+                accumulator.push(refr);
+            }
+        }
+    }
+
     fn range(&self) -> ZeroRange {
         match self {
             Self::Ident(content) => content.range(),

--- a/src/analysis/reference.rs
+++ b/src/analysis/reference.rs
@@ -93,7 +93,7 @@ impl DeclarationSpan for GlobalReference {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ReferenceKind {
     Template,
     Type,
@@ -173,6 +173,12 @@ impl Reference {
                 ZeroSpan::from_range(token.range(),
                                      file.path),
                 kind))
+    }
+    pub fn reference_kind(&self) -> ReferenceKind {
+        match self {
+            Reference::Variable(r) => r.kind,
+            Reference::Global(r) => r.kind,
+        }
     }
 }
 


### PR DESCRIPTION
Allows for the sending of messages to the user when:
- path resolution fails for whatever reason
- isolated analysis not done yet
- device analysis does not exist for this file (known issue in PR; this may also be shown when the device analysis isnt done yet)
- we hit a known internal analysis limitation (currently only isolated template analysis)

Further I want to add known limitation for types, and a system for the user to control how warning is displayed (always, once (per-session), never)

- **Remove unneccessary mut**
- **Remove implicit canonpath->path deref**
- **Change functionality of response-with-message**
- **Remove unused function**
- **Add logic to discern between no-info-found and no-info-available**
- **Add information for some basic DML limitations**
