### PR TITLE
Turn off cargo-outdated temporarily

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -36,15 +36,15 @@ jobs:
           cargo deny --version
           set -o pipefail
           cargo deny check  2>&1 | tee -a ${{ inputs.log-dir }}/deny-log
-      - name: Audit Outdated
-        shell: bash
-        if: ${{ success() || failure() }}
-        run: |
-          rm Cargo.lock
-          cargo install cargo-outdated
-          cargo outdated --version
-          set -o pipefail
-          cargo outdated  --exit-code 1 2>&1 | tee -a ${{ inputs.log-dir }}/outdated-log
+      # - name: Audit Outdated
+      #   shell: bash
+      #   if: ${{ success() || failure() }}
+      #   run: |
+      #     rm Cargo.lock
+      #     cargo install cargo-outdated
+      #     cargo outdated --version
+      #     set -o pipefail
+      #     cargo outdated  --exit-code 1 2>&1 | tee -a ${{ inputs.log-dir }}/outdated-log
       - name: Upload logs
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fairly sure this is not an issue at our end, something upstream has broken cargo-outdateds compatibility with rust 1.83