### PR TITLE
Set 'source' field of diagnostics according to the analysis source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Change Log
 
 ## 0.9.12
+- Diagnostics sent from the server will now indicate their source as 'dml' or 'dml-lint'
 
 ## 0.9.11
 - Fixed deadlock when a configuration update happens


### PR DESCRIPTION
Allows to differentiate errors from other extensions
(and between analysis and linting)

Signed-off-by: Jonatan Waern <jonatan.waern@intel.com>
