### PR TITLE
Add support for provisional 'simics_util_vect'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 0.9.12
 - Diagnostics sent from the server will now indicate their source as 'dml' or 'dml-lint'
+- Added 'simics\_util\_vect' as a known provisional (with no DLS semantics)
 
 ## 0.9.11
 - Fixed deadlock when a configuration update happens

--- a/src/analysis/provisionals.rs
+++ b/src/analysis/provisionals.rs
@@ -15,6 +15,7 @@ use crate::analysis::FileSpec;
 pub enum Provisional {
     // TODO: implement the neccessary checks for explicit params
     ExplicitParamDecl,
+    SimicsUtilVect,
 }
 
 impl fmt::Display for Provisional {
@@ -69,6 +70,7 @@ mod test {
     fn test_provisionals_parsing() {
         for (s, p) in [
             ("explicit_param_decl", Provisional::ExplicitParamDecl),
+            ("simics_util_vect", Provisional::SimicsUtilVect),
         ] {
             assert_eq!(Provisional::from_str(s), Ok(p));
         }


### PR DESCRIPTION
The actual provisional has no effect within the DLS

Signed-off-by: Jonatan Waern <jonatan.waern@intel.com>
