### PR TITLE
Add lint-configuration through comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   has no semantic effect.
 - The parameter declaration patterns ":=" and ": \<type\> = \<val\>" are now
   correctly parsed.
+- You can now annotate dml source to disable reporting of specific lints for specific files or lines,
+  see [USAGE.md](USAGE.md) for instructions on how to use it
 
 ## 0.9.12
 - Added 'simics\_util\_vect' as a known provisional (with no DLS semantics)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ editors, and other tools with information about DML device and common code.
 It currently supports basic syntax error reporting, symbol search,
 'goto-definition', 'goto-implementation', 'goto-reference', and 'goto-base'.
 It also has some basic configurable linting support, in the form of warning
-messages.
+messages. For user-targeted instructions, see [USAGE.md](USAGE.md).
 
 Future planned features are extended semantic and type analysis, basic
 refactoring patterns, improved language construct templates, renaming

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,47 @@
+<!--
+  © 2024 Intel Corporation
+  SPDX-License-Identifier: Apache-2.0 and MIT
+-->
+# Usage Instructions
+This document describes general instructions and advice directed at
+end-users of the DML language server. For advice or details on
+client implementation see [clients.md](clients.md). This document
+_only_ pertains to details that are client-agnostic. For client-specific
+details consult the documentation of the client.
+
+As this file is currently a work in progress, relevant details may be
+missing or incomplete.
+
+## In-Line Linting Configuration
+It may be desireable to control linting on a per-file basis, rather than
+relying on the linting configuration. This can be done with in-line
+linting configuration inside comments.
+
+The general syntax is:
+`// dls-lint: <command>=<target>`
+Note that only one-line comments are allowed, and only if no text is between
+the comment start and 'dls-lint'.
+
+Currently supported commands are:
+* 'allow-file' Will not report the lint rule specified by \<target> for the
+   entire file, regardless of where 'allow-file' is declared
+* 'allow' Will not report the lint rule specified by \<target> for the next
+   line without a leading comment, or for the current line if declared
+   outside a leading comment.
+
+Lint warnings will report which rule caused them in their message, which is the
+same identifier used for \<target>.
+
+For example
+```
+// dls-lint: allow-file=long_lines
+method now_we_can_declare_this_method_with_a_really_really_really_really_long name() {
+
+// dls-lint: allow=nsp_unary
+// dls-lint: allow=indent_no_tabs
+	param p = (1 ++ *
+            4); // dls-lint: allow=indent_paren_expr
+}
+```
+Will allow 'long_lines' globally, 'nsp_unary' and 'indent_no_tabs' on the
+`param p = (1 ++ *` line, and 'indent_paren_expr' on the `'4);` line.

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -268,15 +268,14 @@ pub mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_main() {
         use crate::lint::{begin_style_check, LintCfg};
         use crate::lint::rules:: instantiate_rules;
         let ast = create_ast_from_snippet(SOURCE);
         let cfg = LintCfg::default();
         let rules = instantiate_rules(&cfg);
-        let _lint_errors = begin_style_check(ast, SOURCE, &rules);
-        assert!(_lint_errors.is_ok());
-        assert!(!_lint_errors.unwrap().is_empty());
+        let lint_errors = begin_style_check(ast, SOURCE, &rules);
+        assert!(lint_errors.is_ok());
+        assert!(!lint_errors.unwrap().is_empty());
     }
 }

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -155,7 +155,7 @@ impl LinterAnalysis {
 
 pub fn begin_style_check(ast: TopAst, file: String, rules: &CurrentRules) -> Result<Vec<DMLStyleError>, Error> {
     let mut linting_errors: Vec<DMLStyleError> = vec![];
-    ast.style_check(&mut linting_errors, rules, AuxParams { depth: 0 });      
+    ast.style_check(&mut linting_errors, rules, AuxParams { depth: 0 });
 
     // Per line checks
     let lines: Vec<&str> = file.lines().collect();
@@ -208,7 +208,7 @@ pub mod tests {
     dml 1.4;
 
     bank sb_cr {
-        group monitor {    
+        group monitor {
 
             register MKTME_KEYID_MASK {
                 method get() -> (uint64) {
@@ -230,7 +230,7 @@ pub mod tests {
                 }
             }
         }
-    }   
+    }
 
     /*
         This is ONEEEE VEEEEEERY LLOOOOOOONG COOOMMMEENTT ON A SINGLEEEE LINEEEEEEEEEEEEEE

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -193,9 +193,9 @@ struct LintAnnotations {
 }
 
 lazy_static! {
-    // matches <non-comment?> // dls-lint: <OPERATION> = <IDENT>
+    // matches <non-comment?> // dml-lint: <OPERATION> = <IDENT>
     static ref LINT_ANNOTATION: Regex = Regex::new(
-        r"^(.*)\/\/\s*dls-lint:\s+([a-z-A-Z]+)\s*=\s*([^\s]+)\s*$")
+        r"^(.*)\/\/\s*dml-lint:\s+([a-z-A-Z]+)\s*=\s*([^\s]+)\s*$")
         .unwrap();
     static ref JUST_WHITESPACE: Regex = Regex::new(r"^\s*$").unwrap();
 }
@@ -245,7 +245,7 @@ fn obtain_lint_annotations(file: &str) -> (Vec<DMLStyleError>,
                                 op_capture.start() as u32,
                                 op_capture.end() as u32),
                             description: format!(
-                                "Invalid command '{}' in dls-lint \
+                                "Invalid command '{}' in dml-lint \
                                  annotation.", c),
                         },
                         rule_ident: "LintCfg",
@@ -303,7 +303,7 @@ fn obtain_lint_annotations(file: &str) -> (Vec<DMLStyleError>,
                     last_line as u32,
                     last_line as u32,
                     0, 0),
-                description: "dls-lint annotations without effect at \
+                description: "dml-lint annotations without effect at \
                               end of file."
                     .to_string(),
             },
@@ -443,14 +443,14 @@ pub mod tests {
         use crate::lint::rules::indentation::*;
         use crate::lint::rules::Rule;
 
-        let source = "// dls-lint: allow=long_lines
-                      // dls-lint: allow-file=indent_empty_loop
-                      // dls-lint: allow=indent_switch_case
-                      // dls-lint: allow=unknown_rule
-                      // dls-lint: configure=not_valid
+        let source = "// dml-lint: allow=long_lines
+                      // dml-lint: allow-file=indent_empty_loop
+                      // dml-lint: allow=indent_switch_case
+                      // dml-lint: allow=unknown_rule
+                      // dml-lint: configure=not_valid
                       local int foo = 5;
-                      local bool bar = 0; // dls-lint: allow=indent_paren_expr
-                      // dls-lint: allow=long_lines";
+                      local bool bar = 0; // dml-lint: allow=indent_paren_expr
+                      // dml-lint: allow=long_lines";
         let (errs, mut annotations) = obtain_lint_annotations(source);
         let simplified_errs = errs.into_iter()
             .map(|err|
@@ -471,9 +471,9 @@ pub mod tests {
             .collect::<Vec<_>>();
         assert_eq!(simplified_errs,
                    vec![(3, "Invalid lint rule target 'unknown_rule'.".to_string()),
-                        (4, "Invalid command 'configure' in dls-lint \
+                        (4, "Invalid command 'configure' in dml-lint \
                              annotation.".to_string()),
-                        (7, "dls-lint annotations without effect at \
+                        (7, "dml-lint annotations without effect at \
                              end of file.".to_string())]);
         assert_eq!(annotations.whole_file.iter().collect::<Vec<_>>(),
                    vec![
@@ -514,18 +514,18 @@ pub mod tests {
             "
 dml 1.4;
 
-// dls-lint: allow-file=nsp_unary
+// dml-lint: allow-file=nsp_unary
 
 method my_method() {
     if (true ++) {
-    // dls-lint: allow=indent_closing_brace
+    // dml-lint: allow=indent_closing_brace
         return; }
     if (true) {
-        return; } // dls-lint: allow=indent_closing_brace
+        return; } // dml-lint: allow=indent_closing_brace
     if (true) {
         return; }
 }}
-// dls-lint: allow=long_lines
+// dml-lint: allow=long_lines
 method my_method() { /* now THIS is a long line. but we will allow it just this once*/ }
 method my_method() { /* however, this long line will not be allowed even though its the same*/ }
 ";

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -131,7 +131,7 @@ impl LinterAnalysis {
         debug!("local linting for: {:?}", path);
         let canonpath: CanonPath = path.into();
         let rules =  instantiate_rules(&cfg);
-        let local_lint_errors = begin_style_check(original_analysis.ast, file.text, &rules)?;
+        let local_lint_errors = begin_style_check(original_analysis.ast, &file.text, &rules)?;
         let mut lint_errors = vec![];
         for entry in local_lint_errors {
             let ident = entry.rule_ident;
@@ -153,7 +153,7 @@ impl LinterAnalysis {
     }
 }
 
-pub fn begin_style_check(ast: TopAst, file: String, rules: &CurrentRules) -> Result<Vec<DMLStyleError>, Error> {
+pub fn begin_style_check(ast: TopAst, file: &str, rules: &CurrentRules) -> Result<Vec<DMLStyleError>, Error> {
     let mut linting_errors: Vec<DMLStyleError> = vec![];
     ast.style_check(&mut linting_errors, rules, AuxParams { depth: 0 });
 
@@ -275,7 +275,7 @@ pub mod tests {
         let ast = create_ast_from_snippet(SOURCE);
         let cfg = LintCfg::default();
         let rules = instantiate_rules(&cfg);
-        let _lint_errors = begin_style_check(ast, SOURCE.to_string(), &rules);
+        let _lint_errors = begin_style_check(ast, SOURCE, &rules);
         assert!(_lint_errors.is_ok());
         assert!(!_lint_errors.unwrap().is_empty());
     }

--- a/src/lint/rules/indentation.rs
+++ b/src/lint/rules/indentation.rs
@@ -628,7 +628,7 @@ impl IndentEmptyLoopArgs {
                 semicolon_range: semicolon.range(),
                 expected_depth: depth + 1
             });
-            
+
         }
         None
     }
@@ -640,7 +640,7 @@ impl IndentEmptyLoopArgs {
                 semicolon_range: semicolon.range(),
                 expected_depth: depth + 1
             });
-            
+
         }
         None
     }

--- a/src/lint/rules/mod.rs
+++ b/src/lint/rules/mod.rs
@@ -62,7 +62,7 @@ pub trait Rule {
     }
 }
 
-#[derive(PartialEq, Debug, Clone, Eq, Hash)]
+#[derive(Copy, PartialEq, Debug, Clone, Eq, Hash)]
 pub enum RuleType {
     SpBraces,
     SpPunct,
@@ -77,5 +77,43 @@ pub enum RuleType {
     IN5,
     IN6,
     IN9,
-    IN10
+    IN10,
+    Configuration,
+}
+
+impl std::str::FromStr for RuleType {
+    // More descriptive error than this not needed
+    type Err = ();
+    fn from_str(val: &str) -> Result<RuleType, ()> {
+        macro_rules! get_rule_type {
+            ($v: expr, $rule_class: ty) => {
+                if <$rule_class>::name() == $v {
+                    Ok(<$rule_class>::get_rule_type())
+                } else {
+                    Err(())
+                }
+            };
+            ($v: expr, $rule_class: ty, $($remain_classes:ty),+) => {
+                if <$rule_class>::name() == $v {
+                    Ok(<$rule_class>::get_rule_type())
+                } else {
+                    get_rule_type!($v, $($remain_classes),+)
+                }
+            };
+        }
+        get_rule_type!(val,
+                       LongLinesRule,
+                       IndentNoTabRule,
+                       IndentCodeBlockRule,
+                       IndentClosingBraceRule,
+                       IndentParenExprRule,
+                       IndentSwitchCaseRule,
+                       IndentEmptyLoopRule,
+                       SpBracesRule,
+                       SpPunctRule,
+                       NspFunparRule,
+                       NspInparenRule,
+                       NspUnaryRule,
+                       NspTrailingRule)
+    }
 }

--- a/src/lint/rules/spacing.rs
+++ b/src/lint/rules/spacing.rs
@@ -392,14 +392,14 @@ impl NspInparenRule {
         if !self.enabled { return; }
         if let Some(location) =  ranges {
             if (location.opening.row_end == location.content_start.row_start)
-                && (location.opening.col_end != location.content_start.col_start) { 
+                && (location.opening.col_end != location.content_start.col_start) {
                 let mut gap = location.opening;
                 gap.col_start = location.opening.col_end;
                 gap.col_end = location.content_start.col_start;
                 acc.push(self.create_err(gap));
             }
             if (location.closing.row_start == location.content_end.row_end)
-                && (location.closing.col_start != location.content_end.col_end) { 
+                && (location.closing.col_start != location.content_end.col_end) {
                 let mut gap = location.closing;
                 gap.col_end = location.closing.col_start;
                 gap.col_start = location.content_end.col_end;

--- a/src/lint/rules/tests/common.rs
+++ b/src/lint/rules/tests/common.rs
@@ -34,7 +34,7 @@ pub fn run_linter(source_code: &str, rules: &CurrentRules)
     print!("\nSnippet to test on:\n{}\n", source_code);
     let ast = create_ast_from_snippet(source_code);
     print!("Resulting AST:\n{:#?}\n", ast);
-    begin_style_check(ast, source_code.to_string(), rules)
+    begin_style_check(ast, source_code, rules)
 }
 
 pub fn assert_snippet(source_code: &str, expected_errors: usize, rules: &CurrentRules) {

--- a/src/lint/rules/tests/common.rs
+++ b/src/lint/rules/tests/common.rs
@@ -48,8 +48,8 @@ pub fn robust_assert_snippet(source_code: &str, expected_errors: Vec<ExpectedDML
     let lint_errors = run_linter(source_code, rules).unwrap();
     assert_eq!(lint_errors.len(), expected_errors.len(), "{:#?}", lint_errors);
 
-    let actual_errors: HashSet<_> = lint_errors.iter().map(|e| (e.error.range, e.rule_type.clone())).collect();
-    let expected_errors: HashSet<_> = expected_errors.iter().map(|e| (e.range, e.rule_type.clone())).collect();
+    let actual_errors: HashSet<_> = lint_errors.iter().map(|e| (e.error.range, e.rule_type)).collect();
+    let expected_errors: HashSet<_> = expected_errors.iter().map(|e| (e.range, e.rule_type)).collect();
 
     assert_eq!(actual_errors, expected_errors, "Mismatch between actual and expected errors:\nActual: {:#?}\nExpected: {:#?}", actual_errors, expected_errors);
 }

--- a/src/lint/rules/tests/mod.rs
+++ b/src/lint/rules/tests/mod.rs
@@ -1,4 +1,4 @@
 #[macro_use]
-mod common;
+pub mod common;
 mod indentation;
 mod spacing;


### PR DESCRIPTION
- **Clean trailing whitespace**
- **Dont move string for begin_style_check**
- **Re-enable main lint test**
- **Add support for lint configuration annotations in comments**
- **Introduce the USAGE.md file**
