### PR TITLE
Increment for One Indexed reporting of warnings in DFA CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Moved storage of reference->symbol mapping to on-demand timing, should significantly speed
   up device analysises
 - CLI tool DFA now uses default one-indexed line count for reporting warnings on analyzed files.
-`--zero-indexed` flag can be set to `true` when executing DFA for using zero-indexed counting if required.
+  `--zero-indexed` flag can be set to `true` when executing DFA for using zero-indexed counting if required.
 
 ## 0.9.12
 - Added 'simics\_util\_vect' as a known provisional (with no DLS semantics)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Fixed issue where statements under top-level in-eachs were not correctly tracked.
 - Moved storage of reference->symbol mapping to on-demand timing, should significantly speed
   up device analysises
+- CLI tool DFA now uses default one-indexed line count for reporting warnings on analyzed files.
+`--zero-indexed` flag can be set to `true` when executing DFA for using zero-indexed counting if required.
 
 ## 0.9.12
 - Added 'simics\_util\_vect' as a known provisional (with no DLS semantics)

--- a/src/dfa/client.rs
+++ b/src/dfa/client.rs
@@ -39,7 +39,7 @@ pub struct Diagnostic {
 impl From<lsp_types::Diagnostic> for Diagnostic {
     fn from(diag: lsp_types::Diagnostic) -> Diagnostic {
         Diagnostic {
-            line: diag.range.start.line,
+            line: diag.range.start.line + 1,
             desc: diag.message,
         }
     }

--- a/src/dfa/client.rs
+++ b/src/dfa/client.rs
@@ -39,7 +39,7 @@ pub struct Diagnostic {
 impl From<lsp_types::Diagnostic> for Diagnostic {
     fn from(diag: lsp_types::Diagnostic) -> Diagnostic {
         Diagnostic {
-            line: diag.range.start.line + 1,
+            line: diag.range.start.line,
             desc: diag.message,
         }
     }
@@ -385,13 +385,15 @@ impl ClientInterface {
         }{}
     }
 
-    pub fn output_errors(&self) {
+    pub fn output_errors(&self, zero_indexed: bool) {
         for (path, diagnostics) in &self.diagnostics {
             for diag in diagnostics {
-                println!("{} line {}: {}",
-                         path.to_str().unwrap(),
-                         diag.line,
-                         diag.desc);
+                println!(
+                    "{} line {}: {}",
+                    path.to_str().unwrap(),
+                    diag.line + if zero_indexed { 0 } else { 1 },
+                    diag.desc
+                );
             }
         }
     }


### PR DESCRIPTION
VP Developers have pointed out reported warnings are displayed with a line number which is off by one.

Adding one in this line seems like a quick fix for this, but I'd like to know if there are suggestions of another fix for this.
DFA was originally used for testing, but its now part of the integration into VP development PR checks for DML code, so I think its important for the messages to align with expectations from developers and avoid any confusion when trying to apply corrections for these diagnostics.