### PR TITLE
Capture and log unknown fields from config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed issue where statements under top-level in-eachs were not correctly tracked.
 - Moved storage of reference->symbol mapping to on-demand timing, should significantly speed
   up device analysises
+- Unknown fields in the lint configuration file are now detected and reported as errors, helping users identify and correct typos or unsupported configuration options.
 
 ## 0.9.12
 - Added 'simics\_util\_vect' as a known provisional (with no DLS semantics)

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -249,6 +249,7 @@ impl BlockingNotificationAction for DidChangeWatchedFiles {
         if let Some(file_watch) = FileWatch::new(ctx) {
             if params.changes.iter().any(|c| file_watch.is_relevant(c)) {
                 ctx.update_compilation_info(&out);
+                ctx.update_linter_config(&out);
             }
         }
         Ok(())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -164,6 +164,22 @@ pub(crate) fn maybe_notify_deprecated_configs<O: Output>(out: &O, keys: &[String
     }
 }
 
+pub(crate) fn maybe_notify_unknown_lint_fields<O: Output>(out: &O, unknowns: &[String]) {
+    if !unknowns.is_empty() {
+        let fields_list = unknowns.join(", ");
+        let message = format!(
+            "Unknown lint configuration field{}: {}. These will be ignored.",
+            if unknowns.len() > 1 { "s" } else { "" },
+            fields_list
+        );
+        
+        out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
+            typ: MessageType::ERROR,
+            message,
+        }));
+    }
+}
+
 pub(crate) fn maybe_notify_duplicated_configs<O: Output>(
     out: &O,
     dups: &std::collections::HashMap<String, Vec<String>>,


### PR DESCRIPTION
Capture unknown fields using Serde’s flatten attribute. This approach allows us to accept valid input, ignore unknown fields during normal operation, and log them as needed, instead of rejecting them and using default configuration values.

@jvsqzj 
@alecalvop 