### PR TITLE
Lock version of openssl-sys to known working version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ lsp-types = { version = "0.97" }
 lazy_static = "1.4"
 log = {version = "0.4", features = ["serde"]}
 logos = "0.15"
+openssl-sys = "0.9.109"
 rayon = "1"
 regex = "1.5.5"
 serde = "1.0"


### PR DESCRIPTION
The update breaks building of openssl-sys on non-linux targets, needed for the
internal releases. Will remain until it becomes clearer if this is a bug
in the crate or our build infra. (At the very least, we are not the only ones with
this issue. See: https://github.com/rust-openssl/rust-openssl/issues/2514 )

Signed-off-by: Jonatan Waern <jonatan.waern@intel.com>
