### PR TITLE
Do not use git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ crossbeam = "0.8"
 crossbeam-deque = "0.8.1"
 crossbeam-utils = "0.8.7"
 env_logger = "0.11"
-git2 = "0.20.2"
 itertools = "0.14"
 jsonrpc = "0.18"
 lsp-types = { version = "0.97" }


### PR DESCRIPTION
git2 requires openssl-sys, which does not compile as portably as we'd like

Signed-off-by: Jonatan Waern <jonatan.waern@intel.com>
