### PR TITLE
Correct when DLS warns about config not being under roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Change Log
 
 ## 0.9.16
+- DLS will no longer incorrectly warn about the compile_commands not being under
+  a workspace root when it in fact is
 
 ## 0.9.15
 - Added support for line length and breaking rules regarding line-breaks after opening parentheses, method output arguments, conditional expressions and binary operands.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -462,7 +462,7 @@ impl <O: Output> InitActionContext<O> {
                     compile_info.clone()) {
                     let workspaces = self.workspace_roots.lock().unwrap();
                     if !workspaces.is_empty() &&
-                        workspaces.iter().any(
+                        !workspaces.iter().any(
                             |root|parse_file_path!(&root.uri, "workspace")
                                 .map_or(false, |p|canon_path.as_path()
                                         .starts_with(p))) {


### PR DESCRIPTION
Not sure why this was never hit before, but the condition was
reversed

Signed-off-by: Jonatan Waern <jonatan.waern@intel.com>
