### PR TITLE
Prevent crash when trying to report an invalid URI context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 # Change Log
 
 ## 0.9.18
-
+- Fixed a rare case where the DLS would crash when reporting device contexts
 
 ## 0.9.17
 - Fixed linter wrongly throwing an error on space after `defined` keyword

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -549,8 +549,7 @@ impl <O: Output> InitActionContext<O> {
                         sorted_errors.iter()
                             .map(SourcedDMLError::to_diagnostic).collect(),
                         None)),
-                // The Url crate does not report interesting errors
-                Err(_) => error!("Could not convert {:?} to Url", file),
+                Err(e) => error!("Could not convert {:?} to Url; {}", file, e),
             }
         }
         notifier.notify_end_diagnostics();

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -1075,13 +1075,18 @@ impl RequestAction for GetKnownContextsRequest {
             })
            .filter_map(
                |(path, b, r)|
-               parse_uri(path.as_str()).ok()
-                   .map(|uri|
-                        ContextDefinitionParam {
+               parse_uri(path.as_str())
+                   .map_or_else(
+                    |e|{
+                        internal_error!("Wanted to report a device context which could not be converted to an URI; {}", e);
+                        None
+                    },
+                    |uri|
+                        Some(ContextDefinitionParam {
                             kind: ContextDefinitionKindParam::Device(uri),
                             active: b,
                             ready: r,
-                        }))
+                        })))
            .collect()
         )
     }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -80,7 +80,9 @@ where
 pub fn parse_uri(pathb: &str) -> Result<Uri, UriGenerationError> {
     let canonical = Path::new(pathb)
         .canonicalize()
-        .expect("Could not canonicalize file name");
+        .map_err(|e|UriGenerationError(
+            format!("Could not canonicalize path '{}'; {}",
+                    pathb, e)))?;
     let mut path = canonical.to_str().unwrap();
     // workaround for UNC path (see https://github.com/rust-lang/rust/issues/42869)
     // NOTE: The issue reference is dead but I trust the past


### PR DESCRIPTION
It is uncertain what causes this error in the first place,
but regadless we do not need to crash for it.

Signed-off-by: Jonatan Waern <jonatan.waern@intel.com>
