### PR TITLE
Lock subproccess version to 0.2.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1.0"
 slotmap = "1.0"
 store-interval-tree = "0.4"
 strum = { version = "0.27", features = ["derive"] }
-subprocess = "0.2"
+subprocess = "=0.2.9"
 thiserror = "2.0"
 urlencoding = "2.1"
 utf8-read = "0.4"


### PR DESCRIPTION
From 0.2.10 onwards, it requires rust edition 2024 which
we do not currently use

Signed-off-by: Jonatan Waern <jonatan.waern@intel.com>
