### PR TITLE
Optimization and Bug fixes in Device Analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.9.19
 - Added configuration option to control the max cache size while resolving references in semantic analysis, defaulting to 500MB
 - Added environment variable to control max per-log output length for most logging from the DLS, defaulting to 1000 bytes..
+- Fixed a bug in method-local variable lookups which caused inconsistent results when looking up variables within overridden methods
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added environment variable to control max per-log output length for most logging from the DLS, defaulting to 1000 bytes..
 - Fixed a bug in method-local variable lookups which caused inconsistent results when looking up variables within overridden methods
 - Fixed the reporting range for duplicate template names
+- Fixed a bug that caused intermittent failures around instantiated templates
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 # Change Log
 
 ## 0.9.19
-
+- Added configuration option to control the max cache size while resolving references in semantic analysis, defaulting to 500MB
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 0.9.19
 - Added configuration option to control the max cache size while resolving references in semantic analysis, defaulting to 500MB
-- Added environment variable to control max per-log output length for most logging from the DLS, defaulting to 1000 bytes..
+- Added environment variable to control max per-log output length for most logging from the DLS, defaulting to 1000 bytes
 - Fixed a bug in method-local variable lookups which caused inconsistent results when looking up variables within overridden methods
 - Fixed the reporting range for duplicate template names
 - Fixed a bug that caused intermittent failures around instantiated templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added configuration option to control the max cache size while resolving references in semantic analysis, defaulting to 500MB
 - Added environment variable to control max per-log output length for most logging from the DLS, defaulting to 1000 bytes..
 - Fixed a bug in method-local variable lookups which caused inconsistent results when looking up variables within overridden methods
+- Fixed the reporting range for duplicate template names
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 0.9.19
 - Added configuration option to control the max cache size while resolving references in semantic analysis, defaulting to 500MB
+- Added environment variable to control max per-log output length for most logging from the DLS, defaulting to 1000 bytes..
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ crossbeam = "0.8"
 crossbeam-deque = "0.8.1"
 crossbeam-utils = "0.8.7"
 env_logger = "0.11"
+hashlink = "0.11"
 itertools = "0.14"
 jsonrpc = "0.19"
 lsp-types = { version = "0.97" }

--- a/USAGE.md
+++ b/USAGE.md
@@ -84,6 +84,9 @@ instantiated.
 including direct instantiation sites (so this is a super-set of
 `goto-implementations`)
 
+## Relevant environment variables
+* `MAX_LOG_MESSAGE_LENGTH` When set, will truncate any outputted logs that are longer than the value. Defaults to 1000 bytes. Set to 0 to turn off truncation.
+
 ## In-Line Linting Configuration
 It may be desireable to control linting on a per-file basis, rather than
 relying on the linting configuration. This can be done with in-line

--- a/clients.md
+++ b/clients.md
@@ -35,7 +35,7 @@ Once you have this basic support in place, the hard work begins:
     (note that you need to support dynamic registration of
     "didChangeConfiguration" and support the "workspace/configuration" request on the client
     for pull-style updates)
-  - For the config options, see [config.rs](./src/config.rs#L99-L111)
+  - For the config options, see [config.rs](./src/config.rs#L123-L141)
 * Check for and install the DLS
   - Download the latest [binary](https://github.com/intel/dml-language-server/actions/workflows/rust.yml).
     Currently, official releases are not being made from a public-facing repository. So you should on occassion

--- a/src/actions/analysis_queue.rs
+++ b/src/actions/analysis_queue.rs
@@ -30,7 +30,7 @@ use crate::file_management::CanonPath;
 use crate::vfs::{TextFile, Vfs};
 use crate::server::ServerToHandle;
 
-use log::{info, debug, trace, error};
+use crate::logging::{info, debug, trace, error};
 use crossbeam::channel;
 
 // Maps in-process device jobs the timestamps of their dependencies

--- a/src/actions/analysis_queue.rs
+++ b/src/actions/analysis_queue.rs
@@ -13,6 +13,8 @@ use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicBool;
 use std::thread::{self, Thread};
 use std::time::SystemTime;
+
+use crate::actions::DeviceAnalysisJobOptions;
 use crate::lint::LintCfg;
 use crate::lint::LinterAnalysis;
 
@@ -119,8 +121,9 @@ impl AnalysisQueue {
                               storage: &mut AnalysisStorage,
                               device: &CanonPath,
                               bases: HashSet<CanonPath>,
-                              tracking_token: JobToken) -> bool {
-        match DeviceAnalysisJob::new(tracking_token, storage, bases, device) {
+                              tracking_token: JobToken,
+                              device_analysis_options: DeviceAnalysisJobOptions) -> bool {
+        match DeviceAnalysisJob::new(tracking_token, storage, bases, device, device_analysis_options) {
             Ok(newjob) => {
                 if let Some((_, previous_bases)) = self.device_tracker
                     .lock().unwrap()
@@ -484,13 +487,15 @@ pub struct DeviceAnalysisJob {
     notify: channel::Sender<ServerToHandle>,
     hash: u64,
     token: JobToken,
+    device_analysis_options: DeviceAnalysisJobOptions,
 }
 
 impl DeviceAnalysisJob {
     fn new(token: JobToken,
            analysis: &mut AnalysisStorage,
            bases: HashSet<CanonPath>,
-           root: &CanonPath)
+           root: &CanonPath,
+           device_analysis_options: DeviceAnalysisJobOptions)
            -> Result<DeviceAnalysisJob, String> {
         info!("Creating a device analysis job of {:?}", root);
         // TODO: Use some sort of timestamp from VFS instead of systemtime
@@ -543,6 +548,7 @@ impl DeviceAnalysisJob {
             notify: analysis.notify.clone(),
             hash,
             token,
+            device_analysis_options,
         })
     }
 
@@ -554,6 +560,7 @@ impl DeviceAnalysisJob {
         match DeviceAnalysis::new(self.root,
                                   self.bases,
                                   self.import_sources,
+                                  self.device_analysis_options,
                                   self.token.status) {
             Ok(analysis) => {
                 info!("Finished device analysis of {:?}", analysis.name);

--- a/src/actions/analysis_queue.rs
+++ b/src/actions/analysis_queue.rs
@@ -76,7 +76,7 @@ impl AnalysisQueue {
                               tracking_token: JobToken) -> bool {
         match LinterJob::new(tracking_token, storage, cfg, vfs, file) {
             Ok(newjob) => {
-                self.enqueue(QueuedJob::FileLinterJob(newjob));
+                self.enqueue(newjob.into());
                 true
             },
             Err(desc) => {
@@ -104,7 +104,7 @@ impl AnalysisQueue {
             Ok(newjob) => {
                 debug!("Enqueued isolated analysis job of {}",
                        newjob.path.as_str());
-                self.enqueue(QueuedJob::IsolatedAnalysisJob(newjob));
+                self.enqueue(newjob.into());
                 true
             },
             Err(desc) => {
@@ -146,7 +146,7 @@ impl AnalysisQueue {
                         }
                     }
                 debug!("Enqueued device analysis job of {:?}", device);
-                self.enqueue(QueuedJob::DeviceAnalysisJob(newjob));
+                self.enqueue(newjob.into());
                 true
             },
             Err(desc) => {
@@ -360,14 +360,31 @@ impl Drop for AnalysisQueue {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 enum QueuedJob {
-    IsolatedAnalysisJob(IsolatedAnalysisJob),
-    FileLinterJob(LinterJob),
-    DeviceAnalysisJob(DeviceAnalysisJob),
+    IsolatedAnalysisJob(Box<IsolatedAnalysisJob>),
+    FileLinterJob(Box<LinterJob>),
+    DeviceAnalysisJob(Box<DeviceAnalysisJob>),
     Sentinel,
     Terminate,
+}
+
+impl From<IsolatedAnalysisJob> for QueuedJob {
+    fn from(job: IsolatedAnalysisJob) -> Self {
+        QueuedJob::IsolatedAnalysisJob(Box::new(job))
+    }
+}
+
+impl From<LinterJob> for QueuedJob {
+    fn from(job: LinterJob) -> Self {
+        QueuedJob::FileLinterJob(Box::new(job))
+    }
+}
+
+impl From<DeviceAnalysisJob> for QueuedJob {
+    fn from(job: DeviceAnalysisJob) -> Self {
+        QueuedJob::DeviceAnalysisJob(Box::new(job))
+    }
 }
 
 impl QueuedJob {
@@ -439,7 +456,7 @@ impl IsolatedAnalysisJob {
                     self.context.clone()
                 };
                 let import_paths = analysis.get_import_names();
-                self.report.send(TimestampedStorage::make_isolated_result(
+                self.report.send(TimestampedStorage::make_timestamped(
                     self.timestamp,
                     analysis)).ok();
                 self.notify.send(ServerToHandle::IsolatedAnalysisDone(
@@ -542,7 +559,7 @@ impl DeviceAnalysisJob {
                 info!("Finished device analysis of {:?}", analysis.name);
                 self.notify.send(ServerToHandle::DeviceAnalysisDone(
                     analysis.path.clone())).ok();
-                self.report.send(TimestampedStorage::make_device_result(
+                self.report.send(TimestampedStorage::make_timestamped(
                     self.timestamp,
                     analysis)).ok();
             },
@@ -606,7 +623,7 @@ impl LinterJob {
                                   self.ast,
                                   self.token.status) {
             Ok(analysis) => {
-                self.report.send(TimestampedStorage::make_linter_result(
+                self.report.send(TimestampedStorage::make_timestamped(
                     self.timestamp,
                     analysis)).ok();
                 self.notify.send(ServerToHandle::LinterDone(

--- a/src/actions/analysis_queue.rs
+++ b/src/actions/analysis_queue.rs
@@ -22,7 +22,7 @@ use itertools::{Either, Itertools};
 
 use crate::actions::analysis_storage::{AnalysisStorage, ResultChannel,
                                        TimestampedStorage, timestamp_is_newer};
-use crate::analysis::{DeviceAnalysis, IsolatedAnalysis};
+use crate::analysis::{AnalysisError, DeviceAnalysis, IsolatedAnalysis};
 use crate::analysis::structure::objects::Import;
 
 use crate::concurrency::JobToken;
@@ -468,9 +468,12 @@ impl IsolatedAnalysisJob {
                     import_paths
                 )).ok();
             },
-            Err(e) => {
-                trace!("Failed to create isolated analysis: {}", e);
+            Err(AnalysisError::VFSError(e)) => {
+                error!("Failed to create isolated analysis: {}", e);
                 // TODO: perhaps collect this for reporting to server
+            },
+            Err(AnalysisError::Cancelled) => {
+                debug!("Isolated analysis of {} was cancelled", self.path.as_str());
             }
         }
     }
@@ -553,6 +556,7 @@ impl DeviceAnalysisJob {
     }
 
     fn process(self) {
+        let root_path = self.root.path.clone();
         info!("Started work on deviceanalysis of {:?}, depending on {:?}",
               self.root.path,
               self.bases.iter().map(|i|&i.stored.path)
@@ -571,9 +575,12 @@ impl DeviceAnalysisJob {
                     analysis)).ok();
             },
             // In general, an analysis shouldn't fail to be created
-            Err(e) => {
-                trace!("Failed to create device analysis: {}", e);
+            Err(AnalysisError::VFSError(e)) => {
+                error!("Failed to create device analysis: {}", e);
                 // TODO: perhaps collect this for reporting to server
+            },
+            Err(AnalysisError::Cancelled) => {
+                debug!("Device analysis of {} was cancelled", root_path.as_str());
             }
         }
     }
@@ -636,8 +643,11 @@ impl LinterJob {
                 self.notify.send(ServerToHandle::LinterDone(
                     self.file.clone())).ok();
             },
-            Err(e) => {
-                debug!("Failed to create isolated linter analysis: {}", e);
+            Err(AnalysisError::VFSError(e)) => {
+                error!("Failed to create isolated linter analysis: {}", e);
+            },
+            Err(AnalysisError::Cancelled) => {
+                debug!("Linter analysis of {} was cancelled", self.file.as_str());
             }
         }
     }

--- a/src/actions/analysis_storage.rs
+++ b/src/actions/analysis_storage.rs
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 //! Stores currently completed analysis.
 
-use log::{debug, info, trace};
+use crate::logging::{debug, trace, info};
 
 use crossbeam::channel;
 

--- a/src/actions/analysis_storage.rs
+++ b/src/actions/analysis_storage.rs
@@ -26,12 +26,29 @@ use crate::lint::LinterAnalysis;
 
 use crate::file_management::{PathResolver, CanonPath};
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum AnalysisResult {
-    Isolated(IsolatedAnalysis),
-    Linter(LinterAnalysis),
-    Device(DeviceAnalysis),
+    Isolated(Box<IsolatedAnalysis>),
+    Linter(Box<LinterAnalysis>),
+    Device(Box<DeviceAnalysis>),
+}
+
+impl From<IsolatedAnalysis> for AnalysisResult {
+    fn from(analysis: IsolatedAnalysis) -> Self {
+        AnalysisResult::Isolated(Box::new(analysis))
+    }
+}
+
+impl From<LinterAnalysis> for AnalysisResult {
+    fn from(analysis: LinterAnalysis) -> Self {
+        AnalysisResult::Linter(Box::new(analysis))
+    }
+}
+
+impl From<DeviceAnalysis> for AnalysisResult {
+    fn from(analysis: DeviceAnalysis) -> Self {
+        AnalysisResult::Device(Box::new(analysis))
+    }
 }
 
 impl AnalysisResult {
@@ -52,29 +69,13 @@ pub struct TimestampedStorage<T> {
     pub stored: T,
 }
 
-impl TimestampedStorage<AnalysisResult> {
-    pub fn make_isolated_result(timestamp: SystemTime,
-                                analysis: IsolatedAnalysis)
-                                -> TimestampedStorage<AnalysisResult>{
+impl <T> TimestampedStorage<T> {
+    pub fn make_timestamped<F>(timestamp: SystemTime, result: F) -> Self
+        where F: Into<T>
+    {
         TimestampedStorage {
             timestamp,
-            stored : AnalysisResult::Isolated(analysis),
-        }
-    }
-    pub fn make_device_result(timestamp: SystemTime,
-                              analysis: DeviceAnalysis)
-                              -> TimestampedStorage<AnalysisResult>{
-        TimestampedStorage {
-            timestamp,
-            stored : AnalysisResult::Device(analysis),
-        }
-    }
-    pub fn make_linter_result(timestamp: SystemTime,
-                              analysis: LinterAnalysis)
-                              -> TimestampedStorage<AnalysisResult> {
-        TimestampedStorage {
-            timestamp,
-            stored: AnalysisResult::Linter(analysis),
+            stored: result.into(),
         }
     }
 }
@@ -489,10 +490,7 @@ impl AnalysisStorage {
                             trace!("was new, or fresh compared to previous");
                             dependencies_to_update.insert(canon_path.clone());
                             self.isolated_analysis.insert(canon_path.clone(),
-                                                          TimestampedStorage {
-                                                              timestamp,
-                                                              stored: analysis,
-                                                          });
+                                                          TimestampedStorage::make_timestamped(timestamp, *analysis));
                             self.last_use.insert(canon_path.clone(),
                                                  Mutex::new(SystemTime::now()));
                             self.update_last_use(&canon_path);
@@ -509,10 +507,7 @@ impl AnalysisStorage {
                 AnalysisResult::Linter(analysis) => {
                     let canon_path = analysis.path.clone();
                     self.lint_analysis.insert(canon_path.clone(),
-                                              TimestampedStorage {
-                                                timestamp,
-                                                stored: analysis,
-                                            });
+                                              TimestampedStorage::make_timestamped(timestamp, *analysis));
                 },
             }
         }
@@ -542,10 +537,7 @@ impl AnalysisStorage {
                         trace!("was not invalidated by recent \
                                 isolated analysis");
                         self.device_analysis.insert(canon_path,
-                                                    TimestampedStorage {
-                                                        timestamp,
-                                                        stored: analysis,
-                                                    });
+                                                    TimestampedStorage::make_timestamped(timestamp, *analysis));
                     }
                 }
             } else {

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -1,6 +1,6 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
-use log::*;
+use crate::logging::*;
 
 use crate::span::{Range, ZeroIndexed};
 use serde::{Deserialize, Serialize};

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -362,6 +362,11 @@ impl SourcedDMLError {
 
 pub type ActiveDeviceContexts = HashSet<ContextDefinition>;
 
+#[derive(Debug, Clone)]
+pub struct DeviceAnalysisJobOptions {
+    pub max_reference_cache_size: usize,
+}
+
 impl <O: Output> InitActionContext<O> {
     fn new(
         analysis: Arc<Mutex<AnalysisStorage>>,
@@ -862,13 +867,19 @@ impl <O: Output> InitActionContext<O> {
         let (job, token) = ConcurrentJob::new();
         let job_ident = Self::device_job_id(device.as_str());
         let locked_analysis = &mut self.analysis.lock().unwrap();
+        let device_job_options =
+            DeviceAnalysisJobOptions {
+                    max_reference_cache_size:
+                        self.config.lock().unwrap().max_reference_cache_size,
+            };
         let dependencies = locked_analysis.all_dependencies(device,
                                                             Some(device));
         if self.analysis_queue.enqueue_device_job(
             locked_analysis,
             device,
             dependencies,
-            token) {
+            token,
+            device_job_options) {
             self.add_job(job_ident, job);
         }
     }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -3,7 +3,6 @@
 //! Actions that the DLS can perform: responding to requests, watching files,
 //! etc.
 
-use log::{debug, info, trace, error, warn};
 use thiserror::Error;
 use crossbeam::channel;
 use serde::Deserialize;
@@ -40,6 +39,7 @@ use crate::Span;
 use crate::span;
 use crate::span::{ZeroIndexed, FilePosition};
 use crate::vfs::Vfs;
+use crate::logging::{debug, info, trace, error};
 
 use jsonrpc::error::{standard_error, StandardError};
 use serde_json::Value;
@@ -80,7 +80,7 @@ macro_rules! make_canon_path {
 macro_rules! ignore_non_file_uri {
     ($expr: expr, $uri: expr, $log_name: expr) => {
         $expr.map_err(|_| {
-            log::trace!("{}: Non-`file` URI scheme, ignoring: {:?}", $log_name, $uri);
+            crate::logging::trace!("{}: Non-`file` URI scheme, ignoring: {:?}", $log_name, $uri);
         })
     };
 }
@@ -599,7 +599,7 @@ impl <O: Output> InitActionContext<O> {
                                 .extend(includes.into_iter());
                         }
                     } else {
-                        warn!(
+                        info!(
                             "File in compile information file is not .dml; \
                              {:?}",
                             file

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -8,9 +8,9 @@ use crate::file_management::CanonPath;
 use crate::span::{Span};
 use crate::vfs::{Change, VfsSpan};
 use crate::lsp_data::*;
+use crate::logging::{debug, error};
 
 use jsonrpc::error::StandardError;
-use log::{debug, error, warn};
 use serde::{Serialize, Deserialize};
 
 use lsp_types::notification::ShowMessage;
@@ -211,7 +211,7 @@ impl BlockingNotificationAction for DidChangeConfiguration {
         let new_config = match settings {
             Ok(value) => value.dml,
             Err(err) => {
-                warn!("Received unactionable config: {:?} (error: {:?})", params.settings, err);
+                error!("Received unactionable config: {:?} (error: {:?})", params.settings, err);
                 return Err(().into());
             }
         };

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -3,7 +3,6 @@
 //! Requests that the DLS can respond to.
 
 use jsonrpc::error::StandardError;
-use log::{debug, error, info, trace, warn};
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashSet;
@@ -19,6 +18,7 @@ use crate::actions::semantic_lookup::{DLSLimitation, declarations_at_fp, definit
 use crate::analysis::{Named, DeclarationSpan, LocationSpan};
 use crate::analysis::symbols::SimpleSymbol;
 use crate::config::Config;
+use crate::logging::{debug, error, info, trace};
 
 pub use crate::lsp_data::request::{
     ApplyWorkspaceEdit,
@@ -65,17 +65,17 @@ fn warn_miss_lookup(error: AnalysisLookupError, file: Option<&str>) {
                 if let Some(f) = file { f.to_string() }
                 else { "the opened file".to_string() }),
         AnalysisLookupError::NoIsolatedAnalysis =>
-            warn!(
+            info!(
                 "No syntactical analysis available{}",
                 if let Some(f) = file { format!(" for the file '{}'", f) }
                 else { "".to_string() }),
         AnalysisLookupError::NoLintAnalysis =>
-            warn!(
+            info!(
                 "No linting analysis available{}",
                 if let Some(f) = file { format!(" for the file '{}'", f) }
                 else { "".to_string() }),
         AnalysisLookupError::NoDeviceAnalysis =>
-            warn!(
+            info!(
                 "No semantic analysis available{}, may need to open a file \
                  with a 'device' declaration that imports{}, directly or \
                  indirectly.",
@@ -1002,8 +1002,8 @@ impl SentRequest for WorkspaceConfiguration {
         let new_config = match settings {
             Ok(value) => value,
             Err(err) => {
-                warn!("Received unactionable config: {:?} (error: {:?})",
-                      &response, err);
+                error!("Received unactionable config: {:?} (error: {:?})",
+                        &response, err);
                 return;
             }
         };

--- a/src/actions/semantic_lookup.rs
+++ b/src/actions/semantic_lookup.rs
@@ -156,7 +156,15 @@ fn get_refs_and_syms_at_fp<'t>(
     
     let context_sym_at_pos = context_symbol_at_pos(analysis_info.isolated_analysis, fp);
     let symbols_at_fp = context_sym_at_pos.map(|cs| {
-        analysis_info.device_analysises.iter().map(|a|(*a, a.lookup_symbols(&cs, relevant_limitations))).collect::<Vec<_>>()
+        analysis_info.device_analysises.iter().map(
+            |a|(*a, match a.lookup_symbols(&cs, relevant_limitations) {
+                Ok(syms) => syms,
+                Err(e) => {
+                    internal_error!("failed to find context symbol at {:?}: {}", fp, e);
+                    vec![]
+                }
+            }))
+        .collect::<Vec<_>>()
     });
     if let Some(syms) = symbols_at_fp {
         if ref_at_pos.is_some() {

--- a/src/actions/semantic_lookup.rs
+++ b/src/actions/semantic_lookup.rs
@@ -77,12 +77,32 @@ struct AnalysisInfo <'a> {
     pub device_analysises: Vec<&'a DeviceAnalysis>,
 }
 
+impl std::fmt::Debug for AnalysisInfo<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnalysisInfo")
+        .field("isolated_analysis", &self.isolated_analysis.clientpath.display())
+        .field("device analysis paths", &self.device_analysises.iter().map(|a|a.clientpath.display()).collect::<Vec<_>>())
+        .finish()
+    }
+}
+
 #[allow(dead_code)]
 struct SemanticLookup<'t> {
     pub stored_symbols: DeviceSymbols<'t>,
     pub found_ref: Option<Reference>,
     pub analysis_info: AnalysisInfo<'t>,
     pub recognized_limitations: HashSet<DLSLimitation>,
+}
+
+impl std::fmt::Debug for SemanticLookup<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SemanticLookup")
+        .field("stored_symbols", &self.stored_symbols.iter().map(|(a, syms)| (a.clientpath.display(), syms.iter().map(|s|s.lock().unwrap().medium_debug_info()).collect::<Vec<_>>())).collect::<Vec<_>>())
+        .field("found_ref", &self.found_ref.as_ref())
+        .field("analysis_info", &self.analysis_info)
+        .field("recognized_limitations", &self.recognized_limitations)
+        .finish()
+    }
 }
 
 impl <'t> SemanticLookup<'t> {
@@ -400,6 +420,7 @@ pub fn references_at_fp(context: &InitActionContext<impl Output>,
         &analysis_lock,
         context)?;
     mem::swap(relevant_limitations, &mut semantic_lookup.recognized_limitations);
+    debug!("Lookup at {:?} is {:?}", fp, semantic_lookup);
     Ok(semantic_lookup.symbols()
        .into_iter()
        .flat_map(|s|s.lock().unwrap().references.clone())

--- a/src/actions/semantic_lookup.rs
+++ b/src/actions/semantic_lookup.rs
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 //! Stores currently completed analysis.
 
-use log::{debug, error};
+use crate::logging::{debug, error};
 
 use std::collections::HashSet;
 use std::{fmt, mem};

--- a/src/actions/work_pool.rs
+++ b/src/actions/work_pool.rs
@@ -1,8 +1,9 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 use crate::server::DEFAULT_REQUEST_TIMEOUT;
+use crate::logging::{info, error};
+
 use lazy_static::lazy_static;
-use log::{info, warn};
 use std::sync::{mpsc, Mutex};
 use std::time::{Duration, Instant};
 use std::{fmt, panic};
@@ -62,7 +63,7 @@ where
         if work.len() >= *NUM_THREADS {
             // there are already N ongoing tasks, that may or may not have timed out
             // don't add yet more to the queue fail fast to allow the work pool to recover
-            warn!("Could not start `{}` as at work capacity, {:?} in progress", description, *work,);
+            error!("Could not start `{}` as at work capacity, {:?} in progress", description, *work,);
             return receiver;
         }
         if work.iter().filter(|desc| *desc == &description).count() >= MAX_SIMILAR_CONCURRENT_WORK {
@@ -96,7 +97,7 @@ where
         if elapsed >= *WARN_TASK_DURATION {
             let secs =
                 elapsed.as_secs() as f64 + f64::from(elapsed.subsec_nanos()) / 1_000_000_000_f64;
-            warn!("`{}` took {:.1}s", description, secs);
+            info!("`{}` took {:.1}s", description, secs);
         }
     });
     receiver

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1889,8 +1889,7 @@ fn extend_with_templates(maker: &SymbolMaker,
 
 fn new_symbol_from_object(maker: &SymbolMaker,
                           object: &DMLCompositeObject) -> SymbolRef {
-    let all_decl_defs: Vec<ZeroSpan> = object.all_decls.iter().map(
-        |spec|*spec.loc_span()).collect();
+    let all_decl_defs = &object.all_decls;
     symbol_ref!(
         maker,
         object.declloc,
@@ -1900,7 +1899,7 @@ fn new_symbol_from_object(maker: &SymbolMaker,
         declarations = all_decl_defs.clone(),
         implementations = object.used_ineach_locs.clone().into_iter().collect(),
         // TODO: this does not follow from the new definition of bases
-        bases = all_decl_defs)
+        bases = all_decl_defs.clone())
 }
 
 fn new_symbol_from_arg(maker: &SymbolMaker,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -815,10 +815,16 @@ impl DeviceAnalysis {
                             context_chain: &[ContextKey],
                             limitations: &mut HashSet<DLSLimitation>)
                             -> Result<Vec<DMLObject>, String> {
-        // Note: failing to find here is not actually an error
-        curr_objs.into_iter()
+        let (matches, mut errors): (Vec<_>, Vec<_>) = curr_objs.into_iter()
             .map(|o|self.context_to_objs(o, context_chain, limitations))
-            .process_results(|r|r.flatten().collect())
+            .partition_result();
+        let matches: Vec<_> = matches.into_iter().flatten().collect();
+        if matches.is_empty() {
+            // Hard to tell which error would be the most relevant, so
+            // pick the first one, if any
+            return errors.pop().map(Err).unwrap_or(Ok(vec![]));
+        }
+        Ok(matches)
     }
 
     // TODO: This function is called from two contexts, and this is a reoccuring pain-point

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -67,7 +67,7 @@ use crate::analysis::templating::types::DMLResolvedType;
 use crate::concurrency::AliveStatus;
 use crate::file_management::{PathResolver, CanonPath};
 
-use crate::vfs::{TextFile, Error};
+use crate::vfs::{TextFile, Error as VFSError};
 
 #[derive(Clone, Copy)]
 pub struct FileSpec<'a> {
@@ -654,6 +654,25 @@ fn gather_scopes<'c>(next_scopes: Vec<&'c dyn Scope>,
         gather_scopes(scope.defined_scopes(),
                       new_chain,
                       collected_scopes);
+    }
+}
+
+pub enum AnalysisError {
+    VFSError(VFSError),
+    Cancelled,
+}
+
+pub type AnalysisProcessResult<T> = Result<T, AnalysisError>;
+
+impl From<VFSError> for AnalysisError {
+    fn from(e: VFSError) -> Self {
+        AnalysisError::VFSError(e)
+    }
+}
+
+impl From<AnalysisError> for AnalysisProcessResult<()> {
+    fn from(e: AnalysisError) -> Self {
+        Err(e)
     }
 }
 
@@ -1525,10 +1544,10 @@ impl DeviceAnalysis {
         report: &mut Vec<DMLError>,
         method_structure: &HashMap<ZeroSpan, RangeEntry>,
         reference_cache: &Mutex<ReferenceCache>,
-        status: &AliveStatus) {
+        status: &AliveStatus) -> AnalysisProcessResult<()> {
         if scope_chain.is_empty() {
             internal_error!("Attempted to match references in empty scope chain");
-            return;
+            return Ok(());
         }
         let current_scope = scope_chain.last().unwrap();
         let context_chain: Vec<ContextKey> = scope_chain
@@ -1548,25 +1567,26 @@ impl DeviceAnalysis {
                         Err(e) => {
                             internal_error!("Failed to resolve context chain {:?}: {:?}",
                                             context_chain, e);
-                            return;
+                            return Ok(());
                         }
                     }
             };
         // NOTE: chunk number is arbitrarily picked that benches well
-        report.extend(current_scope.defined_references().par_chunks(25).flat_map(|references|{
-            status.assert_alive();
-            let mut local_reports = vec![];
-            for reference in references {
-                for object in &objects_of_scope {
-                    trace!("In {:?}, Matching {:?}", object, reference);
-                    let symbol_lookup = match &reference.variant {
-                        ReferenceVariant::Variable(var) => self.find_target_for_reference(
-                            Some(object),
-                            var,
-                            method_structure,
-                            reference_cache),
-                            ReferenceVariant::Global(glob) =>
-                            self.lookup_global_from_ref(glob),
+        let errs: AnalysisProcessResult<Vec<_>> = current_scope.defined_references().par_chunks(25).
+            try_fold(|| Vec::new(),
+            |mut local_reports, references|{
+                status.check_alive()?;
+                for reference in references {
+                    for object in &objects_of_scope {
+                        trace!("In {:?}, Matching {:?}", object, reference);
+                        let symbol_lookup = match &reference.variant {
+                            ReferenceVariant::Variable(var) => self.find_target_for_reference(
+                                Some(object),
+                                var,
+                                method_structure,
+                                reference_cache),
+                                ReferenceVariant::Global(glob) =>
+                                self.lookup_global_from_ref(glob),
                         };
 
                         match symbol_lookup.kind {
@@ -1596,15 +1616,18 @@ impl DeviceAnalysis {
                         local_reports.extend(symbol_lookup.messages);
                     }
                 }
-            local_reports.into_par_iter()
-        }).collect::<Vec<_>>());
+                Ok(local_reports)
+            })
+            .try_reduce(Vec::new, |mut vec1, vec2|{ vec1.extend(vec2); Ok(vec1) });
+        report.extend(errs?);
+        Ok(())
     }
 }
 
 pub fn parse_file(path: &Path, file: FileSpec<'_>)
                   -> Result<(parsing::structure::TopAst,
                              ProvisionalsManager,
-                             Vec<DMLError>), Error>
+                             Vec<DMLError>), VFSError>
 {
     let content = &file.file.text;
     let lexer = TokenKind::lexer(content);
@@ -1664,14 +1687,14 @@ impl IsolatedAnalysis {
                clientpath: &PathBuf,
                file: TextFile,
                status: AliveStatus)
-               -> Result<IsolatedAnalysis, Error> {
+               -> AnalysisProcessResult<IsolatedAnalysis> {
         trace!("local analysis: {} at {}", path.as_str(), path.as_str());
-        status.assert_alive();
+        status.check_alive()?;
         let filespec = FileSpec {
             path, file: &file
         };
         let (mut ast, provisionals, mut errors) = parse_file(path, filespec)?;
-        status.assert_alive();
+        status.check_alive()?;
         // Add invalid provisionals to errors
         for duped_provisional in &provisionals.duped_provisionals {
             errors.push(DMLError {
@@ -1727,7 +1750,7 @@ impl IsolatedAnalysis {
 
         let toplevel = collect_toplevel(path, &ast,
                                         &mut errors, filespec);
-        status.assert_alive();
+        status.check_alive()?;
         // sanity, clientpath and path should be the same file
         if CanonPath::from_path_buf(clientpath.clone()).is_none_or(
             |cp|&cp != path) {
@@ -1735,8 +1758,8 @@ impl IsolatedAnalysis {
                     file as the actual path; {:?} vs {:?}",
                    path,
                    clientpath);
-            return Err(Error::InternalError(
-                "Clientpath did not describe the same file as path"));
+            return Err(VFSError::InternalError(
+                "Clientpath did not describe the same file as path").into());
         }
         let top_context = toplevel.to_context();
         let res = IsolatedAnalysis {
@@ -1747,7 +1770,6 @@ impl IsolatedAnalysis {
             clientpath: clientpath.clone(),
             errors,
         };
-        status.assert_alive();
         info!("Produced an isolated analysis of {:?}", res.path);
         debug!("Produced an isolated analysis: {}", res);
         Ok(res)
@@ -2309,7 +2331,7 @@ impl DeviceAnalysis {
                         bases: &Vec<IsolatedAnalysis>,
                         method_structure: &HashMap<ZeroSpan, RangeEntry>,
                         errors: &mut Vec<DMLError>,
-                        status: &AliveStatus) {
+                        status: &AliveStatus) -> AnalysisProcessResult<()> {
         info!("Match references");
         let reference_cache: Mutex<ReferenceCache> = Mutex::new(
             ReferenceCache::new(self.reference_cache_max_size)
@@ -2321,8 +2343,9 @@ impl DeviceAnalysis {
                                            errors,
                                            method_structure,
                                            &reference_cache,
-                                           status);
+                                           status)?;
         }
+        Ok(())
     }
 
     fn template_object_map(tt_info: &TemplateTraitInfo,
@@ -2358,13 +2381,13 @@ impl DeviceAnalysis {
                imp_map: HashMap<Import, String>,
                device_job_options: DeviceAnalysisJobOptions,
                status: AliveStatus)
-               -> Result<DeviceAnalysis, Error> {
+               -> AnalysisProcessResult<DeviceAnalysis> {
         info!("device analysis: {:?}", root.path);
-        status.assert_alive();
+        status.check_alive()?;
 
         if root.toplevel.device.is_none() {
-            return Err(Error::InternalError(
-                "Attempted to device analyze a file without device decl"));
+            return Err(VFSError::InternalError(
+                "Attempted to device analyze a file without device decl").into());
         }
 
         let mut bases: Vec<_> =
@@ -2396,7 +2419,7 @@ impl DeviceAnalysis {
                              .expect("write string error");
                          s
                      }));
-        status.assert_alive();
+        status.check_alive()?;
         let mut errors = vec![];
 
         // Remove duplicate templates
@@ -2432,7 +2455,7 @@ impl DeviceAnalysis {
             trace!("Tracked file {} as template",
                    base.path.to_str().unwrap_or("no path"));
         }
-        status.assert_alive();
+        status.check_alive()?;
         let mut rank_maker = RankMaker::new();
         let tt_info = Self::make_templates_traits(&root.toplevel.start_of_file,
                                                   &mut rank_maker,
@@ -2440,7 +2463,7 @@ impl DeviceAnalysis {
                                                   &files,
                                                   &imp_map,
                                                   &mut errors);
-        status.assert_alive();
+        status.check_alive()?;
         // TODO: catch typedef/traitname overlaps
 
         // TODO: this is where we would do type resolution
@@ -2449,11 +2472,11 @@ impl DeviceAnalysis {
         let device_key = make_device(root.path.as_str(), &root.toplevel,
                                      &tt_info, imp_map, &mut container,
                                      &mut rank_maker, &mut errors).key;
-        status.assert_alive();
+        status.check_alive()?;
         // maps template declaration loc to objects
         let template_object_implementation_map =
             Self::template_object_map(&tt_info, &container);
-        status.assert_alive();
+        status.check_alive()?;
         info!("Generate symbols");
         // Used to handle scoping in methods when looking up local symbols,
         // NOTE: if this meta-information becomes relevant later, move this
@@ -2471,7 +2494,7 @@ impl DeviceAnalysis {
         // symbol order is not correlated to the object iteration order
         bind_method_implementations(&mut symbol_info.method_symbols);
 
-        status.assert_alive();
+        status.check_alive()?;
         // TODO: how do we store type info?
         extend_with_templates(&maker, &mut symbol_info, &tt_info);
         //extend_with_types(&mut symbols, ??)
@@ -2489,11 +2512,11 @@ impl DeviceAnalysis {
             dependant_files: bases.iter().map(|b|&b.path).cloned().collect(),
             reference_cache_max_size: device_job_options.max_reference_cache_size,
         };
-        status.assert_alive();
+        status.check_alive()?;
         device.match_references(&bases,
                                 &method_structure,
                                 &mut errors,
-                                &status);
+                                &status)?;
 
         // NOTE: This is when we previously pre-calculated the ref->symbol map,
         // however the up-front analysis cost of this was too heavy
@@ -2510,7 +2533,7 @@ impl DeviceAnalysis {
                 .push(error);
         }
         trace!("Errors are {:?}", device.errors);
-        status.assert_alive();
+        status.check_alive()?;
         info!("Done with device");
         Ok(device)
     }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -517,7 +517,14 @@ struct ReferenceCache {
 }
 
 fn object_to_path_name(object: Option<&DMLObject>, container: &StructureContainer) -> String {
-    object_to_path_name_aux(object, container, String::new())
+    if let Some(obj) = object.map(|o|o.resolve(container)) {
+        let parent = obj.parent().map(DMLObject::CompObject);
+        object_to_path_name_aux(parent.as_ref(),
+                                container,
+                                obj.identity().to_string())
+    } else {
+        String::new()
+    }
 }
 
 fn object_to_path_name_aux(object: Option<&DMLObject>, container: &StructureContainer, acc: String) -> String {
@@ -2055,7 +2062,7 @@ fn add_method_scope_symbols(maker: &SymbolMaker,
     }
     if !entry.is_empty() {
         method_structure.insert(
-            *method.get_decl().location(),
+            *method.location(),
             entry);
     }
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -292,12 +292,15 @@ impl RangeEntry {
             && self.sub_ranges.iter().all(|sub|sub.is_empty())
     }
     fn find_symbol_for_dmlname(&self, name: &DMLString) -> Option<&SymbolRef> {
+        trace!("Finding symbol for name {:?} at position {:?} in rangeentry {:?}",
+              name.val, name.span.start_position(), self);
         self.find_symbol_for_name(
             &name.val, name.span.start_position().position)
     }
 
     fn find_smallest_scope_around(&self, loc: ZeroPosition)
                                   -> Option<ZeroRange> {
+        trace!("Finding smallest scope around position {:?} in rangeentry {:?}", loc, self);
         if self.range.contains_pos(loc) {
             self.sub_ranges.iter()
                 .find_map(|sub|sub.find_smallest_scope_around(loc))
@@ -564,7 +567,9 @@ impl ReferenceCache {
         let (object, refr) = key;
         let method_scope =
             if let Some(meth) = object.and_then(|o|o.as_shallow()).and_then(|s|s.variant.as_method()) {
-                method_structure.get(meth.location()).and_then(
+                let adjusted_meth = DeviceAnalysis::adjust_method_for_pos(meth, &refr.span().start_position())
+                    .unwrap_or_else(||Arc::clone(meth));
+                method_structure.get(adjusted_meth.location()).and_then(
                         |re|re.find_smallest_scope_around(refr.loc_span().range.start()))
             } else {
                 None
@@ -572,12 +577,13 @@ impl ReferenceCache {
         let object_path = object_to_path_name(object, container);
         let mut agnostic_reference = vec![];
         Self::flatten_ref(&refr.reference, &mut agnostic_reference);
-        ReferenceCacheKey {
+        let res = ReferenceCacheKey {
             object_path,
             agnostic_reference,
             method_scope
-        }
-
+        };
+        trace!("Converted {:?} to agnostic key {:?}", (object, refr), res);
+        res
     }
 
     pub fn get(&mut self,
@@ -626,7 +632,7 @@ impl ReferenceCache {
         let agn_key = Self::convert_to_key(key, container, method_structure);
         if let Some(previous_result) = self.underlying_cache.get(&agn_key) {
             if val != *previous_result {
-                internal_error!("Invariant broken: agnostic keys resulted in different matches, old: {:?}, new: {:?}", previous_result, val);
+                internal_error!("Invariant broken: agnostic keys resulted in different matches, old: {:?}, new: {:?}, agn key: {:?}", previous_result, val, agn_key);
             }
             return;
         }
@@ -1234,6 +1240,32 @@ impl DeviceAnalysis {
         to_ret
     }
 
+    // Returns the method ref in the default chain that contains the loc, if any
+    fn adjust_method_for_pos(method: &Arc<DMLMethodRef>,
+                             pos: &ZeroFilePosition)
+                            -> Option<Arc<DMLMethodRef>> {
+        if !method.span().contains_pos(pos) {
+            match method.get_default() {
+                Some(DefaultCallReference::Valid(defmeth)) => {
+                    return Self::adjust_method_for_pos(defmeth, pos);
+                },
+                Some(DefaultCallReference::Ambiguous(defmeths)) => {
+                    let mut res: Vec<_> = defmeths.iter()
+                        .filter_map(|df|Self::adjust_method_for_pos(df, pos))
+                        .collect();
+                    if res.len() > 1 {
+                        internal_error!("Invariant broken: multiple methods contain the pos {:?} over method {:?}\nhit methods are: {:?}", pos, method, res);
+                    }
+                    return res.pop();
+                },
+                _ => {
+                    trace!("Fell through recursive method noderef resolution for {:?} in method {:?}", pos, method);
+                }
+            }
+        }    
+        None
+    }
+
     fn resolve_simple_noderef_in_method<'c>(&'c self,
                                             parent_key: &StructureKey,
                                             meth: &Arc<DMLMethodRef>,
@@ -1245,37 +1277,10 @@ impl DeviceAnalysis {
         // When resolving a noderef from an overridden method, meth here will be
         // a bottom-most overriding method. So instead find the correct method
         // by recursing to parent
-        if !meth.span().contains_pos(&node.span.start_position()) {
-            match meth.get_default() {
-                Some(DefaultCallReference::Valid(defmeth)) => {
-                    if let Some(defmeth_sym) = self.get_method_symbol(defmeth,
-                                                                     parent_key) {
-                        self.resolve_noderef_in_symbol(
-                            defmeth_sym,
-                            &NodeRef::Simple(node.clone()),
-                            method_structure,
-                            ref_matches);
-                    }
-                },
-                Some(DefaultCallReference::Ambiguous(defmeths)) => {
-                    for defmeth in defmeths {
-                        if let Some(defmeth_sym) = self.get_method_symbol(defmeth,
-                                                                         parent_key) {
-                            self.resolve_noderef_in_symbol(
-                                defmeth_sym,
-                                &NodeRef::Simple(node.clone()),
-                                method_structure,
-                                ref_matches);
-                        }
-                    }
-                },
-                _ => {
-                    trace!("Fell through recursive method noderef resolution for {:?} in method {:?}", node, meth);
-                }
-            }
-            return;
-        }
         trace!("Resolving simple noderef {:?} in method {:?}", node, meth);
+        let Some(adjusted_meth) = Self::adjust_method_for_pos(meth, &node.span().start_position())
+        else { return; };
+        trace!("After adjusting, looking up in {:?}", adjusted_meth);
         match node.val.as_str() {
             "this" =>
                 ref_matches.add_match(Arc::clone(
@@ -1285,7 +1290,7 @@ impl DeviceAnalysis {
             // NOTE: Here we match a default ref to the symbol of the method decl
             // that we directly overrode. Meaning that further lookups on that symbol
             // will be specialized for that overriding chain
-                if let Some(defref) = meth.get_default() {
+                if let Some(defref) = adjusted_meth.get_default() {
                     match defref {
                         DefaultCallReference::Valid(refr) =>  {
                             if let Some(s) = self.get_method_symbol(refr, parent_key) {
@@ -1327,9 +1332,9 @@ impl DeviceAnalysis {
                     // TODO: better error message here, somehow?
                 },
             _ => {
-                let local_sym = method_structure.get(meth.location())
+                let local_sym = method_structure.get(adjusted_meth.location())
                     .and_then(|locals|locals.find_symbol_for_dmlname(node));
-                let arg_sym = meth.args().iter()
+                let arg_sym = adjusted_meth.args().iter()
                     .find(|a|a.name().val == node.val)
                     .map(|a|self.symbol_info.variable_symbols
                          .get(a.loc_span()).unwrap());

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -23,7 +23,7 @@ use hashlink::LinkedHashMap;
 use itertools::Itertools;
 use lsp_types::{DiagnosticSeverity};
 use logos::Logos;
-use log::{debug, error, info, trace};
+use crate::logging::{debug, error, info, trace};
 use rayon::prelude::*;
 
 use crate::actions::{SourcedDMLError, DeviceAnalysisJobOptions};
@@ -1592,7 +1592,7 @@ impl DeviceAnalysis {
                                 (),
                         }
                         local_reports.extend(symbol_lookup.messages);
-                    }
+                    }  
                 }
                 Ok(local_reports)
             })

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1454,30 +1454,8 @@ impl DeviceAnalysis {
         method_structure: &HashMap<ZeroSpan, RangeEntry>,
         reference_cache: &Mutex<ReferenceCache>)
         -> ReferenceMatches {
-        let mut recursive_cache = HashSet::default();
-        self.find_target_for_reference_without_loop(in_object,
-                                                    reference,
-                                                    method_structure,
-                                                    reference_cache,
-                                                    &mut recursive_cache)
-    }
-
-    fn find_target_for_reference_without_loop<'t>(
-        &self,
-        in_object: Option<&'t DMLObject>,
-        reference: &'t VariableReference,
-        method_structure: &HashMap<ZeroSpan, RangeEntry>,
-        reference_cache: &Mutex<ReferenceCache>,
-        recursive_cache: &'t mut HashSet<(String, &'t VariableReference)>)
-        -> ReferenceMatches {
-        // Prevent us from calling into the exact same reference lookup twice
-        // within one lookup.
-        let path_name = object_to_path_name(in_object, &self.objects);
-        if !recursive_cache.insert((path_name, reference)) {
-            internal_error!("Recursive reference lookup detected at \
-                             {:?} under {:?}", reference, in_object);
-            return ReferenceMatches::new();
-        }
+        // NOTE: There was previously a check here to detect infinite recursion loops in reference
+        // lookups, but it was discarded for being overly memory-intensive
         let index_key = (in_object, reference.clone());
         {
             if let Some(cached_result) = reference_cache.lock().unwrap()

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -2423,12 +2423,12 @@ impl DeviceAnalysis {
             let name = &template.obj.object.name.val;
             if unique_templates.contains_key(name.as_str()) {
                 errors.push(DMLError {
-                    span: template.obj.object.span,
+                    span: *template.obj.object.loc_span(),
                     description: format!("Duplicate template name; '{}'", name),
                     severity: Some(DiagnosticSeverity::ERROR),
                     related: vec![(
-                        unique_templates.get(name.as_str()).unwrap()
-                            .obj.object.span,
+                        *unique_templates.get(name.as_str()).unwrap()
+                            .obj.object.loc_span(),
                         "Previously defined here".to_string()
                     )],
                 });

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use itertools::Itertools;
 use lsp_types::{DiagnosticSeverity};
 use logos::Logos;
 use log::{debug, error, info, trace};
@@ -574,16 +575,16 @@ fn gather_scopes<'c>(next_scopes: Vec<&'c dyn Scope>,
 
 impl DeviceAnalysis {
     pub fn lookup_symbols<'t>(&self, context_sym: &ContextedSymbol<'t>, limitations: &mut HashSet<DLSLimitation>)
-        -> Vec<SymbolRef> {
+        -> Result<Vec<SymbolRef>, String> {
         trace!("Looking up symbols at {:?}", context_sym);
 
         // Special handling for methods, since each method decl has its
         // own symbol
         if context_sym.kind() == DMLSymbolKind::Method {
-            return self.symbol_info.method_symbols
+            return Ok(self.symbol_info.method_symbols
                 .get(context_sym.loc_span())
                 .map(|m|m.values().cloned())
-                .into_iter().flatten().collect();
+                .into_iter().flatten().collect());
         }
         self.lookup_symbols_by_contexted_symbol(context_sym, limitations)
     }
@@ -671,23 +672,23 @@ impl DeviceAnalysis {
                         curr_objs: Vec<DMLObject>,
                         context_chain: &[ContextKey],
                         limitations: &mut HashSet<DLSLimitation>)
-                        -> Option<Vec<DMLObject>> {
+                        -> Result<Vec<DMLObject>, String> {
         if context_chain.is_empty() {
-            Some(curr_objs)
+            Ok(curr_objs)
         } else {
             self.contexts_to_objs_aux(
-                curr_objs.into_iter().filter_map(
+                curr_objs.into_iter().map(
                     |obj|match obj.resolve(&self.objects) {
-                        DMLResolvedObject::CompObject(robj) => Some(robj),
+                        DMLResolvedObject::CompObject(robj) => Ok(robj),
                         DMLResolvedObject::ShallowObject(sobj) => {
-                            internal_error!(
+                            Err(format!(
                                 "Internal Error: \
                                  Wanted to find context {:?} in {:?} \
                                  which is not \
-                                 a composite object", sobj, context_chain);
-                            None
+                                 a composite object", sobj, context_chain))
                         }
-                    }).collect(),
+                    })
+                    .collect::<Result<Vec<_>, String>>()?,
                 context_chain,
                 limitations)
         }
@@ -697,15 +698,11 @@ impl DeviceAnalysis {
                             curr_objs: Vec<&DMLCompositeObject>,
                             context_chain: &[ContextKey],
                             limitations: &mut HashSet<DLSLimitation>)
-                            -> Option<Vec<DMLObject>> {
-        let result: Vec<DMLObject> = curr_objs.into_iter()
-            .filter_map(|o|self.context_to_objs(o, context_chain, limitations))
-            .flatten().collect();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
+                            -> Result<Vec<DMLObject>, String> {
+        // Note: failing to find here is not actually an error
+        curr_objs.into_iter()
+            .map(|o|self.context_to_objs(o, context_chain, limitations))
+            .process_results(|r|r.flatten().collect())
     }
 
     // TODO: This function is called from two contexts, and this is a reoccuring pain-point
@@ -717,19 +714,22 @@ impl DeviceAnalysis {
                        curr_obj: &DMLCompositeObject,
                        context_chain: &[ContextKey],
                        limitations: &mut HashSet<DLSLimitation>)
-                       -> Option<Vec<DMLObject>> {
+                       -> Result<Vec<DMLObject>, String> {
         // Should be guaranteed by caller responsibility
         if context_chain.is_empty() {
-            internal_error!(
-                "context chain invariant broken at {:?}",
-                curr_obj.identity());
+            return Err(format!("context chain invariant broken at {:?}", curr_obj.identity()));
         }
 
         let (first, rest) = context_chain.split_first().unwrap();
         let next_objs = match first {
-            ContextKey::Structure(sym) =>
-                curr_obj.get_object(sym.name_ref()).cloned()
-                .into_iter().collect(),
+            ContextKey::Structure(sym) => {
+                let res: Vec<_> = curr_obj.get_object(sym.name_ref()).cloned()
+                    .into_iter().collect();
+                if res.is_empty() {
+                    return Err(format!("Failed to find structural object corresponding to {:?} at {:?}", first, curr_obj.identity()));
+                }
+                res
+            },
             ContextKey::Method(sym) => {
                 if let Some(found_obj)
                     = curr_obj.get_object(sym.name_ref()) {
@@ -740,17 +740,16 @@ impl DeviceAnalysis {
                                 vec![found_obj.clone()]
                             }
                         else {
-                            internal_error!(
+                            return Err(format!(
                                 "Context chain suggested {:?} should be a \
                                  method, but it wasn't",
-                                found_obj.resolve(&self.objects));
-                            vec![]
+                                found_obj.resolve(&self.objects)));
                         }
                     }
                 else {
                     // If it is an error to not find an result, handle
                     // it higher up in stack
-                    return None;
+                    return Err(format!("Failed to find method object corresponding to {:?} at {:?}", first, curr_obj.identity()));
                 }
             },
             ContextKey::Template(sym) =>
@@ -765,26 +764,25 @@ impl DeviceAnalysis {
                             limitations.insert(
                                 isolated_template_limitation(&templ.name)
                             );
+                            return Ok(vec![]);
+                        } else {
+                            return self.contexts_to_objs(
+                                templ_impls
+                                    .iter()
+                                    .map(|key|DMLObject::CompObject(*key))
+                                    .collect(),
+                                rest,
+                                limitations);
                         }
-                        return self.contexts_to_objs(
-                            templ_impls
-                                .iter()
-                                .map(|key|DMLObject::CompObject(*key))
-                                .collect(),
-                            rest,
-                            limitations);
                     }
                     else {
-                        internal_error!(
-                            "No template->objects map for {:?}", sym);
-                        vec![]
+                        return Err(format!("No template->objects map for {:?}", sym));
                     }
                 } else {
-                    internal_error!(
+                    return Err(format!(
                         "Wanted to find context {:?} in {:?} which is not \
                          a known template object",
-                        first, curr_obj);
-                    return None;
+                        first, curr_obj));
                 },
             ContextKey::AllWithTemplate(_, templates) =>
                 return self.contexts_to_objs(
@@ -1020,7 +1018,7 @@ impl DeviceAnalysis {
             }
     }
 
-    fn lookup_global_sym(&self, sym: &SimpleSymbol) -> Vec<SymbolRef> {
+    fn lookup_global_sym(&self, sym: &SimpleSymbol) -> Result<Vec<SymbolRef>, String> {
         //TODO: being able to fail a re-match here feels silly. consider
         // adding sub-enum for DMLGlobalSymbolKind
         match sym.kind {
@@ -1029,21 +1027,18 @@ impl DeviceAnalysis {
                     sym.name.as_str()) {
                     // This _should_ be guaranteed, since the SimpleSymbol
                     // ref comes from structure
-                    vec![Arc::clone(self.symbol_info.template_symbols.get(
-                        templ.location.as_ref().unwrap()).unwrap())]
+                    Ok(vec![Arc::clone(self.symbol_info.template_symbols.get(
+                        templ.location.as_ref().unwrap()).unwrap())])
                 } else {
-                    error!("Unexpectedly missing template matching {:?}", sym);
-                    vec![]
+                    Err(format!("Unexpectedly missing template matching {:?}", sym))
                 }
             },
             // TODO: DMLType lookup
-            DMLSymbolKind::Typedef => vec![],
+            DMLSymbolKind::Typedef => Ok(vec![]),
             // TODO: Extern lookup
-            DMLSymbolKind::Extern => vec![],
+            DMLSymbolKind::Extern => Ok(vec![]),
             e => {
-                error!("Internal error: Unexpected symbol kind of global \
-                        symbol: {:?}", e);
-                vec![]
+                Err(format!("Unexpected symbol kind of global symbol: {:?}", e))
             },
         }
     }
@@ -1052,7 +1047,7 @@ impl DeviceAnalysis {
     pub fn lookup_symbols_by_contexted_symbol<'t>(&self,
                                                   sym: &ContextedSymbol<'t>,
                                                   limitations: &mut HashSet<DLSLimitation>)
-        -> Vec<SymbolRef> {
+        -> Result<Vec<SymbolRef>, String> {
         if matches!(sym.symbol.kind, DMLSymbolKind::Template |
                     DMLSymbolKind::Typedef | DMLSymbolKind::Extern)
         {
@@ -1061,36 +1056,28 @@ impl DeviceAnalysis {
 
         debug!("Looking up {:?} in device tree", sym);
 
-        let mb_objs = if sym.contexts.is_empty() {
-            Some(vec![self.get_device_obj().clone()])
+        let objs = if sym.contexts.is_empty() {
+            vec![self.get_device_obj().clone()]
         } else {
             self.context_to_objs(self.get_device_comp_obj(),
                                  sym.contexts.iter()
                                  .cloned().cloned()
                                  .collect::<Vec<ContextKey>>()
                                  .as_slice(),
-                                 limitations)
+                                 limitations)?
         };
 
-        if let Some(objs) = mb_objs {
-            trace!("Found {:?}", objs);
-            let mut refs = ReferenceMatches::new();
-            let _: Vec<_> = objs.into_iter()
-                .map(|o|self.lookup_def_in_obj(&o, sym.symbol, &mut refs))
-                .collect();
-            // We can ignore messages from lookup defs here, as this lookup is
-            // live and reporting additional things from here makes no sense
-            if let Some(matches) = refs.as_matches() {
-                matches.into_iter().collect()
-            } else {
-                vec![]
-            }
+        trace!("Found {:?}", objs);
+        let mut refs = ReferenceMatches::new();
+        let _: Vec<_> = objs.into_iter()
+            .map(|o|self.lookup_def_in_obj(&o, sym.symbol, &mut refs))
+            .collect();
+        // We can ignore messages from lookup defs here, as this lookup is
+        // live and reporting additional things from here makes no sense
+        if let Some(matches) = refs.as_matches() {
+            Ok(matches.into_iter().collect())
         } else {
-            // TODO: Do we need to fall back on globals here? Can we get an
-            // identifier from a spot that is generic enough to refer to a
-            // global, but also is in a context where a global makes sense?
-            internal_error!("Failed to find objects matching {:?}", sym);
-            vec![]
+            Ok(vec![])
         }
     }
 
@@ -1462,23 +1449,25 @@ impl DeviceAnalysis {
         let current_scope = scope_chain.last().unwrap();
         let context_chain: Vec<ContextKey> = scope_chain
             .iter().map(|s|s.create_context()).collect();
-        let Some(objects_of_scope) = (
+        let objects_of_scope = 
             if context_chain.len() == 1 {
                 // Must be device object
-                Some(vec![self.get_device_obj().clone()])
+                vec![self.get_device_obj().clone()]
             } else {
-                self.context_to_objs(
+                match self.context_to_objs(
                     self.get_device_comp_obj(),
                     // Skip first context, it's the device one
                     &context_chain[1..],
                     // Intentionally avoid storing limitations
-                    &mut HashSet::new())
-            }
-        )                 
-        else {
-            debug!("Context chain {:?} corresponded to no objects", context_chain);
-            return;
-        };
+                    &mut HashSet::new()) {
+                        Ok(objs) => objs,
+                        Err(e) => {
+                            internal_error!("Failed to resolve context chain {:?}: {:?}",
+                                            context_chain, e);
+                            return;
+                        }
+                    }
+            };
         // NOTE: chunk number is arbitrarily picked that benches well
         report.extend(current_scope.defined_references().par_chunks(25).flat_map(|references|{
             status.assert_alive();

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -517,6 +517,8 @@ struct ReferenceCache {
     underlying_cache: LinkedHashMap<ReferenceCacheKey, ReferenceMatches>,
     used_size: usize,
     allowed_size: usize,
+    enabled: bool,
+    num_insert_failures: usize,
 }
 
 fn object_to_path_name(object: Option<&DMLObject>, container: &StructureContainer) -> String {
@@ -544,10 +546,15 @@ fn object_to_path_name_aux(object: Option<&DMLObject>, container: &StructureCont
 
 impl ReferenceCache {
     fn new(size: usize) -> Self {
+        if size == 0 {
+            debug!("Auto-disabled reference cache due to designated size being 0");
+        }
         ReferenceCache {
             underlying_cache: LinkedHashMap::new(),
             used_size: 0,
             allowed_size: size,
+            enabled: size > 0,
+            num_insert_failures: 0,
         }
     }
 
@@ -591,6 +598,9 @@ impl ReferenceCache {
                container: &StructureContainer,
                method_structure: &HashMap<ZeroSpan, RangeEntry>)
                -> Option<&ReferenceMatches> {
+        if !self.enabled {
+            return None;
+        }
         let agn_key = Self::convert_to_key(key, container, method_structure);
         match self.underlying_cache.raw_entry_mut().from_key(&agn_key) {
             hashlink::linked_hash_map::RawEntryMut::Occupied(mut e) => {
@@ -629,6 +639,9 @@ impl ReferenceCache {
                   container: &StructureContainer,
                   method_structure: &HashMap<ZeroSpan, RangeEntry>)
     {
+        if !self.enabled {
+            return;
+        }
         let agn_key = Self::convert_to_key(key, container, method_structure);
         if let Some(previous_result) = self.underlying_cache.get(&agn_key) {
             if val != *previous_result {
@@ -639,6 +652,11 @@ impl ReferenceCache {
         let added_size = Self::size_of_key_val(&agn_key, &val);
         if let Err(e) = self.prepare_space(added_size) {
             internal_error!("Failed to insert '{:?}' into reference cache: {}", agn_key, e);
+            self.num_insert_failures += 1;
+            if self.num_insert_failures > 10 {
+                info!("Auto-disabling reference cache due to repeated insert failures, consider increasing the cache size limit");
+                self.enabled = false;
+            }
             return;
         }
         self.used_size += added_size;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -19,14 +19,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use hashlink::LinkedHashMap;
 use itertools::Itertools;
 use lsp_types::{DiagnosticSeverity};
 use logos::Logos;
 use log::{debug, error, info, trace};
 use rayon::prelude::*;
 
-use crate::actions::SourcedDMLError;
-use crate::actions::analysis_storage::TimestampedStorage;
+use crate::actions::{SourcedDMLError, DeviceAnalysisJobOptions};
+use crate::actions::analysis_storage::{TimestampedStorage};
 use crate::actions::semantic_lookup::{DLSLimitation, isolated_template_limitation};
 use crate::analysis::symbols::{DMLSymbolKind, SimpleSymbol, StructureSymbol, SymbolContainer, SymbolMaker, SymbolSource};
 pub use crate::analysis::symbols::SymbolRef;
@@ -186,6 +187,12 @@ impl Hash for DMLError {
 }
 
 impl DMLError {
+    fn size_of(&self) -> usize {
+        std::mem::size_of_val(self)
+         + self.description.len()
+         + self.related.iter().fold(0, |a, (_, m)| a + std::mem::size_of::<ZeroSpan>() + m.len())
+    }
+
     pub fn with_source(self, source: &'static str) -> SourcedDMLError {
         SourcedDMLError {
             error: self,
@@ -372,6 +379,7 @@ pub struct DeviceAnalysis {
     pub path: CanonPath,
     pub dependant_files: Vec<CanonPath>,
     pub clientpath: PathBuf,
+    pub reference_cache_max_size : usize,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -381,7 +389,7 @@ pub enum ReferenceMatchKind {
     NotFound,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ReferenceMatches {
     pub kind: ReferenceMatchKind,
     // How these references are interpreted depends on 'kind',
@@ -403,6 +411,14 @@ impl Default for ReferenceMatches {
 }
 
 impl ReferenceMatches {
+    fn size_of(&self) -> usize {
+        // NOTE: This does NOT count the size of the values under the symbolrefs, as these should be shared with
+        // the analysis
+        std::mem::size_of_val(self)
+         + self.references.len() * std::mem::size_of::<SymbolRef>()
+         + self.messages.iter().fold(0, |a, m| a + m.size_of())
+    }
+
     pub fn add_match(&mut self, reference: SymbolRef) {
         if self.kind != ReferenceMatchKind::MismatchedFind {
             self.kind = ReferenceMatchKind::Found;
@@ -479,10 +495,25 @@ pub type TypeHint = DMLResolvedType;
 // Agnostic reference
 type AgnRef = Vec<String>;
 
-type ReferenceCacheKey = (String, AgnRef, Option<ZeroRange>);
-#[derive(Default)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct ReferenceCacheKey {
+    object_path: String,
+    agnostic_reference: AgnRef,
+    method_scope: Option<ZeroRange>,
+}
+
+impl ReferenceCacheKey {
+    fn size_of(&self) -> usize {
+        std::mem::size_of_val(self)
+         + self.object_path.len()
+         + self.agnostic_reference.iter().fold(0, |a, s| a + s.len())
+    }
+}
+
 struct ReferenceCache {
-    underlying_cache: HashMap<ReferenceCacheKey, ReferenceMatches>,
+    underlying_cache: LinkedHashMap<ReferenceCacheKey, ReferenceMatches>,
+    used_size: usize,
+    allowed_size: usize,
 }
 
 fn object_to_path_name(object: Option<&DMLObject>, container: &StructureContainer) -> String {
@@ -502,6 +533,14 @@ fn object_to_path_name_aux(object: Option<&DMLObject>, container: &StructureCont
 }
 
 impl ReferenceCache {
+    fn new(size: usize) -> Self {
+        ReferenceCache {
+            underlying_cache: LinkedHashMap::new(),
+            used_size: 0,
+            allowed_size: size,
+        }
+    }
+
     fn flatten_ref(refr: &NodeRef, agn: &mut Vec<String>) {
         match refr {
             NodeRef::Simple(dmlstring) => agn.push(dmlstring.val.clone()),
@@ -526,16 +565,49 @@ impl ReferenceCache {
         let object_path = object_to_path_name(object, container);
         let mut agnostic_reference = vec![];
         Self::flatten_ref(&refr.reference, &mut agnostic_reference);
-        (object_path, agnostic_reference, method_scope)
+        ReferenceCacheKey {
+            object_path,
+            agnostic_reference,
+            method_scope
+        }
+
     }
 
-    pub fn get(&self,
+    pub fn get(&mut self,
                key: (Option<&DMLObject>, VariableReference),
                container: &StructureContainer,
                method_structure: &HashMap<ZeroSpan, RangeEntry>)
                -> Option<&ReferenceMatches> {
         let agn_key = Self::convert_to_key(key, container, method_structure);
-        self.underlying_cache.get(&agn_key)
+        match self.underlying_cache.raw_entry_mut().from_key(&agn_key) {
+            hashlink::linked_hash_map::RawEntryMut::Occupied(mut e) => {
+                // Update cache entry to be recently used
+                e.to_back();
+                Some(e.into_mut())
+            },
+            _ => None,
+        }
+    }
+
+    fn size_of_key_val(key: &ReferenceCacheKey, val: &ReferenceMatches) -> usize {
+        key.size_of() + val.size_of()
+    }
+
+    fn remove_oldest(&mut self) {
+        // Unwrap is guaranteed by caller, a.k.a. do not speculatively call this function
+        let (oldest_key, oldest_val) = self.underlying_cache.pop_front().unwrap();
+        let removed_size = Self::size_of_key_val(&oldest_key, &oldest_val);
+        self.used_size -= removed_size;
+    }
+
+    fn prepare_space(&mut self, added_size: usize) -> Result<(), &'static str>{
+        if added_size > self.allowed_size {
+            return Err("Not enough space allowed in cache");
+        }
+        while self.used_size + added_size > self.allowed_size {
+            self.remove_oldest();
+        }
+        Ok(())
     }
 
     pub fn insert(&mut self,
@@ -545,6 +617,18 @@ impl ReferenceCache {
                   method_structure: &HashMap<ZeroSpan, RangeEntry>)
     {
         let agn_key = Self::convert_to_key(key, container, method_structure);
+        if let Some(previous_result) = self.underlying_cache.get(&agn_key) {
+            if val != *previous_result {
+                internal_error!("Invariant broken: agnostic keys resulted in different matches, old: {:?}, new: {:?}", previous_result, val);
+            }
+            return;
+        }
+        let added_size = Self::size_of_key_val(&agn_key, &val);
+        if let Err(e) = self.prepare_space(added_size) {
+            internal_error!("Failed to insert '{:?}' into reference cache: {}", agn_key, e);
+            return;
+        }
+        self.used_size += added_size;
         self.underlying_cache.insert(agn_key, val);
     }
 }
@@ -1449,7 +1533,7 @@ impl DeviceAnalysis {
         let current_scope = scope_chain.last().unwrap();
         let context_chain: Vec<ContextKey> = scope_chain
             .iter().map(|s|s.create_context()).collect();
-        let objects_of_scope = 
+        let objects_of_scope =
             if context_chain.len() == 1 {
                 // Must be device object
                 vec![self.get_device_obj().clone()]
@@ -2227,7 +2311,9 @@ impl DeviceAnalysis {
                         errors: &mut Vec<DMLError>,
                         status: &AliveStatus) {
         info!("Match references");
-        let reference_cache: Mutex<ReferenceCache> = Mutex::default();
+        let reference_cache: Mutex<ReferenceCache> = Mutex::new(
+            ReferenceCache::new(self.reference_cache_max_size)
+        );
         for scope_chain in all_scopes(bases) {
             debug!("Got scope at {:?}", scope_chain.last()
                    .map(|s|s.span().start_position()));
@@ -2270,6 +2356,7 @@ impl DeviceAnalysis {
     pub fn new(root: IsolatedAnalysis,
                timed_bases: Vec<TimestampedStorage<IsolatedAnalysis>>,
                imp_map: HashMap<Import, String>,
+               device_job_options: DeviceAnalysisJobOptions,
                status: AliveStatus)
                -> Result<DeviceAnalysis, Error> {
         info!("device analysis: {:?}", root.path);
@@ -2400,6 +2487,7 @@ impl DeviceAnalysis {
             path: root.path.clone(),
             clientpath: root.path.clone().into(),
             dependant_files: bases.iter().map(|b|&b.path).cloned().collect(),
+            reference_cache_max_size: device_job_options.max_reference_cache_size,
         };
         status.assert_alive();
         device.match_references(&bases,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -568,7 +568,7 @@ impl ReferenceCache {
         let method_scope =
             if let Some(meth) = object.and_then(|o|o.as_shallow()).and_then(|s|s.variant.as_method()) {
                 let adjusted_meth = DeviceAnalysis::adjust_method_for_pos(meth, &refr.span().start_position())
-                    .unwrap_or_else(||Arc::clone(meth));
+                    .unwrap_or(meth);
                 method_structure.get(adjusted_meth.location()).and_then(
                         |re|re.find_smallest_scope_around(refr.loc_span().range.start()))
             } else {
@@ -1241,9 +1241,9 @@ impl DeviceAnalysis {
     }
 
     // Returns the method ref in the default chain that contains the loc, if any
-    fn adjust_method_for_pos(method: &Arc<DMLMethodRef>,
-                             pos: &ZeroFilePosition)
-                            -> Option<Arc<DMLMethodRef>> {
+    fn adjust_method_for_pos<'t>(method: &'t Arc<DMLMethodRef>,
+                                 pos: &ZeroFilePosition)
+                            -> Option<&'t Arc<DMLMethodRef>> {
         if !method.span().contains_pos(pos) {
             match method.get_default() {
                 Some(DefaultCallReference::Valid(defmeth)) => {
@@ -1259,11 +1259,12 @@ impl DeviceAnalysis {
                     return res.pop();
                 },
                 _ => {
-                    trace!("Fell through recursive method noderef resolution for {:?} in method {:?}", pos, method);
+                    internal_error!("Fell through recursive method noderef resolution for {:?} in method {:?}", pos, method);
+                    return None;
                 }
             }
         }    
-        None
+        Some(method)
     }
 
     fn resolve_simple_noderef_in_method<'c>(&'c self,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1933,7 +1933,7 @@ fn add_new_symbol_from_shallow(maker: &SymbolMaker,
         SymbolSource::DMLObject(
             // TODO: Inefficient clone. Not terribly so, but worth
             // noting
-            DMLObject::ShallowObject(shallow.clone())),
+            DMLObject::ShallowObject(Box::new(shallow.clone()))),
         bases = bases,
         definitions = definitions,
         declarations = declarations);

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1263,7 +1263,7 @@ impl DeviceAnalysis {
                     return None;
                 }
             }
-        }    
+        }
         Some(method)
     }
 
@@ -1306,7 +1306,7 @@ impl DeviceAnalysis {
                                    ref_matches.set_mismatched(Arc::clone(s));
                                 }
                             }
-                             let ambiguous_desc: &'static str 
+                             let ambiguous_desc: &'static str
                             = "Ambiguous default call, you may need to clarify the template ordering or use a template-qualified-method-implementation-call";
                             ref_matches.add_message(DMLError {
                                     span: *node.span(),
@@ -1423,7 +1423,7 @@ impl DeviceAnalysis {
                                             subnode,
                                             method_structure,
                                             &mut intermediate_matches);
-                
+
                 if let Some(syms) = intermediate_matches.as_matches() {
                     let wrapped_simple = NodeRef::Simple(simple.clone());
                     for sym in syms {
@@ -1605,7 +1605,7 @@ impl DeviceAnalysis {
                                 (),
                         }
                         local_reports.extend(symbol_lookup.messages);
-                    }  
+                    }
                 }
                 Ok(local_reports)
             })
@@ -1977,7 +1977,7 @@ fn add_new_symbol_from_method(maker: &SymbolMaker, parent_obj_key: &StructureKey
                 add_new_symbol_from_method(maker, parent_obj_key, default, errors, storage, method_structure);
             }
         }
-    }   
+    }
 }
 
 #[allow(clippy::ptr_arg)]
@@ -2010,7 +2010,7 @@ fn add_new_symbol_from_shallow(maker: &SymbolMaker,
              vec![*hook.loc_span()],
              vec![*hook.loc_span()]),
     };
-    
+
     let new_sym = symbol_ref!(
         maker,
         *shallow.location(),

--- a/src/analysis/parsing/parser.rs
+++ b/src/analysis/parsing/parser.rs
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 use logos::Lexer;
 use regex::Regex;
-use log::trace;
+use crate::logging::trace;
 use lazy_static::lazy_static;
 
 use crate::span::{Range, ZeroIndexed, Position};

--- a/src/analysis/parsing/statement.rs
+++ b/src/analysis/parsing/statement.rs
@@ -1,6 +1,6 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
-use log::error;
+use crate::logging::error;
 
 use crate::lint::rules::indentation::{IndentEmptyLoopArgs,
     IndentContinuationLineArgs};

--- a/src/analysis/parsing/statement.rs
+++ b/src/analysis/parsing/statement.rs
@@ -666,32 +666,51 @@ impl TreeElement for ForPostElement {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForPreDeclaration {
+    pub decl_kind: LeafToken,
+    pub declarations: VarDecl,
+    pub initializer: Option<(LeafToken, Initializer)>
+}
+
+impl TreeElement for ForPreDeclaration {
+    fn range(&self) -> ZeroRange {
+        Range::combine(self.decl_kind.range(),
+                       match &self.initializer {
+                           Some((_, init)) => init.range(),
+                           None => self.declarations.range(),
+                       })
+    }
+    fn subs(&self) -> TreeElements<'_> {
+        create_subs!(&self.decl_kind, &self.declarations, &self.initializer)
+    }
+    fn post_parse_sanity(&self, _file: &TextFile) -> Vec<LocalDMLError> {
+        self.declarations.ensure_named()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ForPre {
-    Declaration(LeafToken, VarDecl, Option<(LeafToken, Initializer)>),
+    Declaration(Box<ForPreDeclaration>),
     Post(ForPost),
 }
 
 impl TreeElement for ForPre {
     fn range(&self) -> ZeroRange {
         match self {
-            Self::Declaration(loc, vardecls, init) =>
-                Range::combine(Range::combine(loc.range(), vardecls.range()),
-                               init.range()),
+            Self::Declaration(forpre) => forpre.range(),
             Self::Post(forpost) => forpost.range(),
         }
     }
     fn subs(&self) -> TreeElements<'_> {
         match self {
-            Self::Declaration(loc, vardecls, init) =>
-                create_subs!(loc, vardecls, init),
+            Self::Declaration(forpre) => create_subs!(forpre.as_ref()),
             Self::Post(forpost) => create_subs!(forpost),
         }
     }
     fn post_parse_sanity(&self, _file: &TextFile) -> Vec<LocalDMLError> {
-        if let ForPre::Declaration(_, cdecl, _) = self {
-            cdecl.ensure_named()
+        if let ForPre::Declaration(forpre) = self {
+            forpre.post_parse_sanity(_file)
         } else {
             vec![]
         }
@@ -824,7 +843,7 @@ fn parse_forpre(context: &ParseContext, stream: &mut FileParser<'_>, file_info: 
     match new_context.peek_kind(stream) {
         Some(TokenKind::Local | TokenKind::Saved | TokenKind::Session) => {
             let decl_kind = new_context.next_leaf(stream);
-            let decls = parse_vardecl(&new_context, stream, file_info);
+            let declarations = parse_vardecl(&new_context, stream, file_info);
             let initializer = match new_context.peek_kind(stream) {
                 Some(TokenKind::Assign) => {
                     let equals = new_context.next_leaf(stream);
@@ -834,7 +853,11 @@ fn parse_forpre(context: &ParseContext, stream: &mut FileParser<'_>, file_info: 
                 },
                 _ => None,
             };
-            ForPre::Declaration(decl_kind, decls, initializer)
+            ForPre::Declaration(Box::new(ForPreDeclaration {
+                decl_kind,
+                declarations,
+                initializer,
+            }))
         },
         _ => ForPre::Post(parse_forpost(&new_context, stream, file_info)),
     }
@@ -1003,12 +1026,11 @@ fn parse_switchhashif(context: &ParseContext, stream: &mut FileParser<'_>, file_
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum SwitchCase {
     Statement(Statement),
     Case(LeafToken, Expression, LeafToken),
-    HashIf(SwitchHashIf),
+    HashIf(Box<SwitchHashIf>),
     Default(LeafToken, LeafToken),
 }
 
@@ -1028,7 +1050,7 @@ impl TreeElement for SwitchCase {
         match self {
             Self::Statement(content) => create_subs!(content),
             Self::Case(case, expr, colon) => create_subs!(case, expr, colon),
-            Self::HashIf(content) => create_subs!(content),
+            Self::HashIf(content) => create_subs!(content.as_ref()),
             Self::Default(default, colon) => create_subs!(default, colon),
         }
     }
@@ -1050,7 +1072,7 @@ fn parse_switchcase(context: &ParseContext, stream: &mut FileParser<'_>, file_in
     let mut new_context = context.enter_context(doesnt_understand_tokens);
     match new_context.peek_kind(stream) {
         Some(TokenKind::HashIf) => SwitchCase::HashIf(
-            parse_switchhashif(&new_context, stream, file_info)),
+            Box::new(parse_switchhashif(&new_context, stream, file_info))),
         Some(TokenKind::Case) => {
             let case = new_context.next_leaf(stream);
             let mut colon_context = new_context.enter_context(
@@ -2315,7 +2337,7 @@ mod test {
                 make_leaf(zero_range(0, 0, 21, 21),
                           zero_range(0, 0, 21, 22),
                           TokenKind::Colon)),
-            SwitchCase::HashIf(hashif),
+            SwitchCase::HashIf(Box::new(hashif)),
             SwitchCase::Statement(
                 make_ast(
                     zero_range(0, 0, 43, 47),

--- a/src/analysis/parsing/structure.rs
+++ b/src/analysis/parsing/structure.rs
@@ -1,7 +1,7 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 // Types, traits, and structs for the structure of a DML file
-use log::{trace, error};
+use crate::logging::{error, trace};
 
 use crate::analysis::parsing::expression::{Expression,
                                            ensure_string_concatenation};

--- a/src/analysis/parsing/structure.rs
+++ b/src/analysis/parsing/structure.rs
@@ -1838,7 +1838,6 @@ impl Parse<DMLObjectContent> for ErrorObjectContent {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum DMLObjectContent {
     Attribute(CompositeObjectContent),

--- a/src/analysis/scope.rs
+++ b/src/analysis/scope.rs
@@ -8,7 +8,7 @@ use crate::analysis::reference::{Reference};
 
 use crate::analysis::structure::objects::Method;
 
-use log::{debug, trace};
+use crate::logging::{debug, trace};
 
 pub trait Scope : DeclarationSpan + Named {
     // Need this to create default mappings

--- a/src/analysis/structure/expressions.rs
+++ b/src/analysis/structure/expressions.rs
@@ -1,6 +1,6 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
-use log::{error};
+use crate::logging::{error};
 
 use std::num::{IntErrorKind, ParseIntError};
 

--- a/src/analysis/structure/statements.rs
+++ b/src/analysis/structure/statements.rs
@@ -1,6 +1,6 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
-use log::error;
+use crate::logging::error;
 
 use crate::analysis::{DeclarationSpan,
                       LocalDMLError};

--- a/src/analysis/structure/statements.rs
+++ b/src/analysis/structure/statements.rs
@@ -433,9 +433,10 @@ impl For {
             ||vec![],
             |post|to_forpost(post, report, file));
         let pre = content.pre.as_ref().and_then(|pre|match pre {
-            statement::ForPre::Declaration(kind, vardecls, maybe_init) =>
-                to_variable(kind, vardecls,
-                            maybe_init.as_ref().map(|(_, init)|init),
+            statement::ForPre::Declaration(forpre) =>
+                to_variable(&forpre.decl_kind,
+                            &forpre.declarations,
+                            forpre.initializer.as_ref().map(|(_, init)|init),
                             report, file)
                 .map(ForPre::Declaration),
             statement::ForPre::Post(p) => Some(ForPre::Post(

--- a/src/analysis/structure/toplevel.rs
+++ b/src/analysis/structure/toplevel.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Display, Formatter, self as fmt};
 use std::path::PathBuf;
 
-use log::trace;
+use crate::logging::trace;
 
 use crate::analysis::structure::objects::{Bitorder, CBlock, CompObjectKind, CompositeObject, Constant, DMLObject, DMLStatement, Device, Error, Export, Hook, Import, InEach, Instantiation, Loggroup, Method, MethodModifier, Parameter, Statements, Template, ToStructure, Typedef, Variable, Version, make_statements};
 use crate::analysis::structure::expressions::{Expression};

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -109,7 +109,7 @@ impl SimpleSymbol {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum SymbolSource {
     DMLObject(DMLObject),
     // (key of containing object, method ref)
@@ -121,6 +121,37 @@ pub enum SymbolSource {
     // TODO: RC this if it's expensive
     Type(DMLResolvedType),
     Template(Arc<DMLTemplate>),
+}
+
+impl std::fmt::Debug for SymbolSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SymbolSource::DMLObject(_) => 
+                f.debug_struct("SymbolSource::DMLObject")
+                .finish_non_exhaustive(),
+            SymbolSource::Method(_, meth) =>
+                f.debug_struct("SymbolSource::Method")
+                .field("name", &meth.concrete_decl.decl.name.val)
+                .finish_non_exhaustive(),
+            SymbolSource::MethodArg(meth, name) => 
+                f.debug_struct("SymbolSource::MethodArg")
+                .field("argument_name", &name.val)
+                .field("method_name", &meth.concrete_decl.decl.name.val)
+                .finish_non_exhaustive(),
+            SymbolSource::MethodLocal(meth, name) => 
+                f.debug_struct("SymbolSource::MethodLocal")
+                .field("name", &name.val)
+                .field("method_name", &meth.concrete_decl.decl.name.val)
+                .finish_non_exhaustive(),
+            SymbolSource::Type(_) => 
+                f.debug_struct("SymbolSource::Type")
+                .finish_non_exhaustive(),
+            SymbolSource::Template(templ) => 
+                f.debug_struct("SymbolSource::Template")
+                .field("name", &templ.name)
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 impl SymbolSource {
@@ -257,10 +288,22 @@ impl SymbolMaker {
     }
 }
 
-#[derive(Debug)]
 pub struct SymbolRefInner {
     pub id: SymbolID,
     pub symbol: Mutex<Symbol>,
+}
+
+impl std::fmt::Debug for SymbolRefInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.symbol.lock() {
+            Ok(symbol) => f.debug_tuple("SymbolRef")
+                .field(&symbol.medium_debug_info())
+                .finish(),
+            Err(_) => f.debug_tuple("SymbolRef")
+                .field(&format!("Symbol(id={}) <lock poisoned>", self.id))
+                .finish()
+        }
+    }
 }
 
 pub type SymbolRef = Arc<SymbolRefInner>;

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -109,7 +109,6 @@ impl SimpleSymbol {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SymbolSource {
     DMLObject(DMLObject),

--- a/src/analysis/templating/objects.rs
+++ b/src/analysis/templating/objects.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::sync::Arc;
 
-use log::{debug, trace, error};
+use crate::logging::{debug, trace, error};
 use lsp_types::DiagnosticSeverity;
 use slotmap::{DefaultKey, Key, SlotMap};
 

--- a/src/analysis/templating/objects.rs
+++ b/src/analysis/templating/objects.rs
@@ -561,7 +561,7 @@ impl DMLHierarchyMember for DMLShallowObject {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum DMLShallowObjectVariant {
     Method(Arc<DMLMethodRef>),
     Session(DMLVariable),
@@ -569,6 +569,44 @@ pub enum DMLShallowObjectVariant {
     Parameter(DMLParameter),
     Constant(Constant),
     Hook(Box<ObjectDecl<Hook>>),
+}
+
+impl std::fmt::Debug for DMLShallowObjectVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DMLShallowObjectVariant::Method(m) => f
+                .debug_struct("Method")
+                .field("name", &m.identity())
+                .field("location", m.location())
+                .field("trait", &m.template_ref.as_ref().map(|t|t.name.to_string()))
+                .finish(),
+            DMLShallowObjectVariant::Session(s) => f
+                .debug_struct("Session")
+                .field("name", s.name())
+                .field("location", s.loc_span())
+                .finish(),
+            DMLShallowObjectVariant::Saved(s) => f
+                .debug_struct("Saved")
+                .field("name", s.name())
+                .field("location", s.loc_span())
+                .finish(),
+            DMLShallowObjectVariant::Parameter(p) => f
+                .debug_struct("Parameter")
+                .field("name", p.name())
+                .field("location", p.loc_span())
+                .finish(),
+            DMLShallowObjectVariant::Constant(c) => f
+                .debug_struct("Constant")
+                .field("name", c.name())
+                .field("location", c.loc_span())
+                .finish(),
+            DMLShallowObjectVariant::Hook(h) => f
+                .debug_struct("Hook")
+                .field("name", h.obj.name())
+                .field("location", h.obj.loc_span())
+                .finish(),
+        }
+    }
 }
 
 impl DMLShallowObjectVariant {

--- a/src/analysis/templating/objects.rs
+++ b/src/analysis/templating/objects.rs
@@ -365,13 +365,12 @@ pub trait DMLHierarchyMember : DMLNamedMember {
 // underlying objects carry their own multiple definitions
 // This means we might miss some cases where we refer to a composite object
 // that does not actually exist
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DMLObject {
     // This is a key to be used in the structure dictionary for
     // current device analysis
     CompObject(StructureKey),
-    ShallowObject(DMLShallowObject),
+    ShallowObject(Box<DMLShallowObject>),
 }
 
 impl DMLObject {
@@ -562,7 +561,6 @@ impl DMLHierarchyMember for DMLShallowObject {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DMLShallowObjectVariant {
     Method(Arc<DMLMethodRef>),
@@ -570,7 +568,7 @@ pub enum DMLShallowObjectVariant {
     Saved(DMLVariable),
     Parameter(DMLParameter),
     Constant(Constant),
-    Hook(ObjectDecl<Hook>),
+    Hook(Box<ObjectDecl<Hook>>),
 }
 
 impl DMLShallowObjectVariant {
@@ -833,28 +831,28 @@ impl DMLCompositeObject {
     }
     pub fn get_param<T>(&self, name: T) -> Option<&DMLParameter>
     where T: std::borrow::Borrow<str> + Sized {
-        if let Some(DMLObject::ShallowObject(
-            DMLShallowObject {
+        self.get_object(name).and_then(|obj|
+            if let Some(DMLShallowObject {
                 variant: DMLShallowObjectVariant::Parameter(param),
                 ..
-            })) = self.get_object(name) {
-            Some(param)
-        } else {
-            None
-        }
+            }) = obj.as_shallow() {
+                Some(param)
+            } else {
+                None
+            })
     }
 
     pub fn get_method<T>(&self, name: T) -> Option<Arc<DMLMethodRef>>
     where T: std::borrow::Borrow<str> + Sized {
-        if let Some(DMLObject::ShallowObject(
-            DMLShallowObject {
+        self.get_object(name).and_then(|obj|
+            if let Some(DMLShallowObject {
                 variant: DMLShallowObjectVariant::Method(meth),
                 ..
-            })) = self.get_object(name) {
-            Some(Arc::clone(meth))
-        } else {
-            None
-        }
+            }) = obj.as_shallow() {
+                Some(Arc::clone(meth))
+            } else {
+                None
+            })
     }
 
     pub fn dimensions(&self, container: &StructureContainer) -> usize {
@@ -873,15 +871,16 @@ impl DMLCompositeObject {
     pub fn parameters<'t>(&'t self)
                           -> impl Iterator<Item=&'t DMLParameter> + 't {
         self.components.values().filter_map(
-            |c| if let DMLObject::ShallowObject(
-                DMLShallowObject {
+            |c|c.as_shallow().and_then(|s|
+            if let DMLShallowObject {
                     variant: DMLShallowObjectVariant::Parameter(p),
                     ..
-                }) = c {
+                } = s{
                 Some(p)
             } else {
                 None
             })
+        )
     }
 
     pub fn add_composite_component(&mut self,
@@ -909,10 +908,10 @@ impl DMLCompositeObject {
                    });
         } else {
             self.components.insert(child.identity().to_string(),
-                                   DMLObject::ShallowObject(DMLShallowObject {
+                                   DMLObject::ShallowObject(Box::new(DMLShallowObject {
                                        parent: self.key,
                                        variant: child,
-                                   }));
+                                   })));
         }
     }
 }
@@ -1047,7 +1046,7 @@ fn add_hooks(obj: &mut DMLCompositeObject,
         if used {
             let (_, hook) = hook_decls.swap_remove(0);
             obj.add_shallow_component(
-                DMLShallowObjectVariant::Hook(hook));
+                DMLShallowObjectVariant::Hook(Box::new(hook)));
         }
     }
 }

--- a/src/analysis/templating/objects.rs
+++ b/src/analysis/templating/objects.rs
@@ -321,7 +321,6 @@ pub fn make_device<'t>(path: &str,
         &device_decl.name,
         device_decl.decl.kind,
         vec![],
-        vec![],
         vec![faux_spec],
         &InEachSpec::default(),
         None,
@@ -844,14 +843,12 @@ pub struct DMLCompositeObject {
     pub declloc: ZeroSpan,
     // These are the ranges of the objectspecs declared with the
     // objects name
-    pub all_decls: Vec<Arc<ObjectSpec>>,
+    pub all_decls: Vec<ZeroSpan>,
     pub identity: DMLString,
     // Reference to self, let's us pass obj refs rather than
     // keys to functions unless necessary
     pub key: StructureKey,
     pub kind: CompObjectKind,
-    // These are the full objectspecs used to define this object, non-semantic
-    pub definitions: Vec<Arc<ObjectSpec>>,
     // These are the immediate parents
     pub templates: HashMap<String, Arc<DMLTemplate>>,
     pub parent: Option<StructureKey>,
@@ -1365,7 +1362,7 @@ fn resolve_parameter(obj_loc: &ZeroSpan,
 }
 
 fn create_object_instance(loc: Option<ZeroSpan>,
-                          all_decls: Vec<Arc<ObjectSpec>>,
+                          all_decls: &Vec<Arc<ObjectSpec>>,
                           identity: &DMLString,
                           kind: CompObjectKind,
                           array_info: &[ArrayDim],
@@ -1386,12 +1383,11 @@ fn create_object_instance(loc: Option<ZeroSpan>,
            all_decls);
     let obj = DMLCompositeObject {
         declloc: loc.unwrap_or(identity.span),
-        all_decls,
+        all_decls: all_decls.iter().map(|s|*s.loc_span()).collect(),
         identity: identity.clone(),
         used_ineach_locs: vec![],
         key: StructureKey::null(),
         kind,
-        definitions: vec![],
         templates: HashMap::default(),
         parent: None,
         arraydimvars: array_info.to_vec(),
@@ -1780,7 +1776,6 @@ fn merge_composite_subobj<'c>(name: String,
                 &auth_obj.obj.object.name,
                 *auth_kind,
                 array_info.iter().map(|(d, _)|d).cloned().collect(),
-                specs.iter().map(|(_, s)|Arc::clone(s)).collect(),
                 object_specs,
                 parent_each_stmts,
                 parent_key,
@@ -2266,7 +2261,6 @@ pub fn make_object(loc: ZeroSpan,
                    identity: &DMLString,
                    kind: CompObjectKind,
                    array_info: Vec<ArrayDim>,
-                   merged_obj_specs: Vec<Arc<ObjectSpec>>,
                    mut obj_specs: Vec<Arc<ObjectSpec>>,
                    parent_each_stmts: &InEachSpec,
                    parent_key: Option<StructureKey>,
@@ -2300,7 +2294,7 @@ pub fn make_object(loc: ZeroSpan,
            symbols.keys().map(|k|k.as_str()).collect::<Vec<&str>>());
 
     let new_obj_key = create_object_instance(Some(loc),
-                                             merged_obj_specs,
+                                             &obj_specs,
                                              identity, kind,
                                              &array_info, container);
 
@@ -2310,7 +2304,6 @@ pub fn make_object(loc: ZeroSpan,
 
     {
         let new_obj = container.get_mut(new_obj_key).unwrap();
-        new_obj.definitions = obj_specs.clone();
         new_obj.used_ineach_locs = used_ineach_locs;
         add_templates(new_obj, &obj_specs);
         add_constants(new_obj, constants);

--- a/src/analysis/templating/topology.rs
+++ b/src/analysis/templating/topology.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use log::{debug, error, trace};
+use crate::logging::{debug, error, trace};
 use lsp_types::DiagnosticSeverity;
 
 use crate::analysis::DeclarationSpan;

--- a/src/analysis/templating/topology.rs
+++ b/src/analysis/templating/topology.rs
@@ -283,6 +283,8 @@ pub fn dependencies<'t>(statements: &'t StatementSpec,
             InferiorVariant::Object(obj) => {
                 queue.extend(obj.spec.objects.iter().map(
                     |o|InferiorVariant::Object(o)));
+                queue.push(InferiorVariant::ImplicitIs(
+                    &obj.obj.kind));
                 queue.extend(obj.spec.ineachs.iter().map(
                     |o|InferiorVariant::InEach(o)));
                 queue.extend(obj.spec.instantiations.iter().map(

--- a/src/analysis/templating/topology.rs
+++ b/src/analysis/templating/topology.rs
@@ -175,6 +175,7 @@ pub fn create_templates_traits<'t>(
     let mut templates = HashMap::default();
     let mut traits = HashMap::default();
     debug!("template order is: {:?}", order);
+
     for templname in order {
         let templ = &template_specs[templname];
         let rankinf = &rank_struct[templname];

--- a/src/analysis/templating/traits.rs
+++ b/src/analysis/templating/traits.rs
@@ -23,7 +23,7 @@ use crate::analysis::templating::topology::Rank;
 
 use crate::analysis::DeclarationSpan;
 
-use log::{debug, error, trace};
+use crate::logging::{debug, error, trace};
 use lsp_types::DiagnosticSeverity;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -41,7 +41,7 @@ use std::time::{Duration, Instant};
 use serde_json;
 use lazy_static::lazy_static;
 
-use log::debug;
+use crate::logging::debug;
 
 /// Runs the DLS in command line mode.
 pub fn run(compile_info_path: Option<PathBuf>,

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -4,6 +4,8 @@ use std::thread;
 use std::collections::HashMap;
 use std::sync::{Arc, Weak};
 
+use crate::analysis::AnalysisError;
+
 use crossbeam::channel::{bounded, select, Receiver, Select, Sender};
 
 /// `ConcurrentJob` is a handle for some long-running computation
@@ -48,9 +50,11 @@ impl AliveStatus {
     pub fn is_alive(&self) -> bool {
         self.0.strong_count() > 0
     }
-    pub fn assert_alive(&self) {
-        if !self.is_alive() {
-            panic!("Sub-job killed");
+    pub fn check_alive(&self) -> Result<(), AnalysisError> {
+        if self.is_alive() {
+            Ok(())
+        } else {
+            Err(AnalysisError::Cancelled)
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 
-use log::{error, trace};
+use crate::logging::{error, trace};
 
 use crate::lsp_data::SerializeError;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,9 @@ pub struct Config {
     pub compile_info_path: Option<PathBuf>,
     pub analysis_retain_duration: Option<f64>,
     pub new_device_context_mode: DeviceContextMode,
+    /// Max size of the data in the reference cache while resolving references,
+    /// does not include cache overhead
+    pub max_reference_cache_size: usize,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -222,6 +225,7 @@ impl Default for Config {
             compile_info_path: None,
             analysis_retain_duration: None,
             new_device_context_mode: DeviceContextMode::Always,
+            max_reference_cache_size: 500_000_000,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,7 +138,7 @@ pub struct Config {
     pub analysis_retain_duration: Option<f64>,
     pub new_device_context_mode: DeviceContextMode,
     /// Max size of the data in the reference cache while resolving references,
-    /// does not include cache overhead
+    /// does not include cache overhead. Setting to 0 disables the cache
     pub max_reference_cache_size: usize,
 }
 

--- a/src/dfa/client.rs
+++ b/src/dfa/client.rs
@@ -28,7 +28,7 @@ use crate::server::{self, Notification};
 use crate::cmd;
 use crate::lsp_data::{parse_file_path, parse_uri};
 
-use log::{debug, trace};
+use crate::logging::{debug, trace};
 
 #[derive(Debug, PartialEq)]
 pub struct Diagnostic {

--- a/src/dfa/main.rs
+++ b/src/dfa/main.rs
@@ -13,7 +13,6 @@ use std::io::Write;
 use clap::{command, arg, Arg, ArgAction};
 
 use dls::dfa::ClientInterface;
-
 use log::debug;
 
 pub fn main() {

--- a/src/file_management.rs
+++ b/src/file_management.rs
@@ -1,7 +1,7 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 //! Contains utilities and file management
-use log::{debug, error, trace};
+use crate::logging::{debug, error, trace};
 
 use std::collections::HashMap;
 use std::fs;

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use lazy_static::lazy_static;
-use log::{debug, error, trace};
+use crate::logging::{debug, error, trace};
 use rules::linelength::{BreakBeforeBinaryOpOptions,
     BreakFuncCallOpenParenOptions,
     BreakMethodOutputOptions,

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -34,7 +34,7 @@ use rules::{spacing::{SpReservedOptions,
                 IndentSwitchCaseOptions,
                 IndentEmptyLoopOptions,
                 IndentContinuationLineOptions}};
-use crate::analysis::{DMLError, IsolatedAnalysis, LocalDMLError, ZeroRange};
+use crate::analysis::{AnalysisProcessResult, DMLError, IsolatedAnalysis, LocalDMLError, ZeroRange};
 use crate::analysis::parsing::tree::TreeElement;
 use crate::file_management::CanonPath;
 use crate::vfs::{Error, TextFile};
@@ -211,16 +211,16 @@ impl LinterAnalysis {
                cfg: LintCfg,
                original_analysis: IsolatedAnalysis,
                status: AliveStatus)
-               -> Result<LinterAnalysis, Error> {
+               -> AnalysisProcessResult<LinterAnalysis> {
         debug!("local linting for: {:?}", path);
-        status.assert_alive();
+        status.check_alive()?;
         let canonpath = CanonPath::try_from_path_buf(path.to_path_buf())
             .map_err(|e|Error::Io(Some(path.to_path_buf()),
                                   Some(e.to_string())))?;
         let rules =  instantiate_rules(&cfg);
         let local_lint_errors = begin_style_check(
             original_analysis.ast, &file.text, &rules)?;
-        status.assert_alive();
+        status.check_alive()?;
         let mut lint_errors = vec![];
         for entry in local_lint_errors {
             let ident = entry.rule_ident;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,6 +1,70 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 
+use std::sync::LazyLock;
+
+macro_rules! info {
+    ($($arg:tt)*) => {
+        crate::log_with_fn!(log::info, log::Level::Info, $($arg)*)
+    };
+}
+
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        crate::log_with_fn!(log::trace, log::Level::Trace, $($arg)*)
+    };
+}
+
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        crate::log_with_fn!(log::debug, log::Level::Debug, $($arg)*)
+    };
+}
+
+macro_rules! error {
+    ($($arg:tt)*) => {
+        crate::log_with_fn!(log::error, log::Level::Error, $($arg)*)
+    };
+}
+
+#[allow(clippy::crate_in_macro_def)]
+#[macro_export]
+macro_rules! log_with_fn {
+    ($log:path, $level:expr, $($arg:tt)*) => {
+        if (log::log_enabled!($level)) {
+            $log!("{}", $crate::format_truncated!(*crate::logging::MAX_LOG_MESSAGE_LENGTH, $($arg)*));
+        }
+    }
+}
+
+pub (crate) use {debug, error, info, trace};
+
+pub static MAX_LOG_MESSAGE_LENGTH: LazyLock<Option<usize>> =
+    LazyLock::new(|| {
+        std::env::var("MAX_LOG_MESSAGE_LENGTH").ok()
+            .or_else(||Some("1000".to_string()))
+            .and_then(|s| s.parse().ok())
+    });
+
+#[macro_export]
+macro_rules! format_truncated {
+    ($trunc_len:expr, $($arg:tt)*) => {{
+        let s = format!($($arg)*);
+        'check_block: {
+            if let Some(max_len) = $trunc_len {
+                if max_len > 0 && s.len() > max_len {
+                    let mut slice_index = max_len;
+                    while !s.is_char_boundary(slice_index) {
+                        slice_index -= 1;
+                    }
+                    break 'check_block [&s[..slice_index], " ..."].concat();
+                }
+            }
+            s
+        }
+    }};
+}
+
 pub fn init() {
     // Slightly dumb way to do this, build the logger once with defaults
     // to get the max level for all modules from env, then build again
@@ -15,4 +79,30 @@ pub fn init() {
 
 pub fn set_global_log_level(level: log::LevelFilter) {
     log::set_max_level(level);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_format_truncated() {
+        let s = format_truncated!(Some(5), "Hello, world!");
+        assert_eq!(s, "Hello ...");
+        let s = format_truncated!(Some(20), "Hello, world!");
+        assert_eq!(s, "Hello, world!");
+        let s = format_truncated!(None, "Hello, world!");
+        assert_eq!(s, "Hello, world!");
+    }
+
+    #[test]
+    fn test_format_unicode() {
+        // These particular emojis are 4 bytes each
+        let s = format_truncated!(Some(8), "😀😀😀😀😀");
+        assert_eq!(s, "😀😀 ...");
+        let s = format_truncated!(Some(7), "😀😀😀😀😀");
+        assert_eq!(s, "😀 ...");
+        let s = format_truncated!(Some(11), "😀😀😀😀😀");
+        assert_eq!(s, "😀😀 ...");
+        let s = format_truncated!(Some(30), "😀😀😀😀😀");
+        assert_eq!(s, "😀😀😀😀😀");
+    }
 }

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 use jsonrpc::error::StandardError::InternalError;
-use log::{info, error, debug};
+use crate::logging::{info, error, debug};
 
 use crate::actions::work_pool;
 use crate::actions::work_pool::WorkDescription;

--- a/src/server/io.rs
+++ b/src/server/io.rs
@@ -1,7 +1,7 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
 use jsonrpc::error::{RpcError, StandardError, standard_error};
-use log::{debug, trace};
+use crate::logging::{debug, trace};
 use serde_json::Value;
 
 use super::{Notification, Request, RequestId};

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -10,7 +10,7 @@ use jsonrpc::error::{
     standard_error,
     StandardError::{self, InvalidParams, InvalidRequest, ParseError},
 };
-use log::debug;
+use crate::logging::debug;
 use lsp_types::notification::ShowMessage;
 use serde::ser::{SerializeStruct, Serializer};
 use serde::Deserialize;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -323,13 +323,16 @@ impl<O: Output> LsService<O> {
     pub fn run(mut self) -> i32 {
         let client_reader_send = self.server_send.clone();
         let client_reader_output = self.output.clone();
-        let client_reader_msg_reader = Arc::clone(&self.msg_reader);
+        let client_reader_msg_reader = Arc::downgrade(&self.msg_reader);
         // Start client reader thread
         thread::spawn(move || {
-            let msg_reader = client_reader_msg_reader;
+            let msg_reader_weak = client_reader_msg_reader;
             let output = client_reader_output;
             let send = client_reader_send;
             loop {
+                let Some(msg_reader) = msg_reader_weak.upgrade() else {
+                    return;
+                };
                 trace!("Awaiting message");
                 let msg_string = match msg_reader.read_message() {
                     Some(m) => m,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,8 +25,9 @@ pub use crate::server::message::{
     RequestId, Response, ResponseError, ResponseWithMessage,
 };
 use crate::version;
+use crate::logging::{debug, error, info, trace};
+
 use jsonrpc::error::StandardError;
-use log::{debug, error, info, trace, warn};
 pub use lsp_types::notification::{Exit as ExitNotification, ShowMessage};
 pub use lsp_types::request::Initialize as InitializeRequest;
 pub use lsp_types::request::Shutdown as ShutdownRequest;
@@ -117,11 +118,7 @@ pub(crate) fn maybe_notify_unknown_configs<O: Output>(_out: &O, unknowns: &[Stri
         write!(msg, "{}`{}` ", if first { ' ' } else { ',' }, key).unwrap();
         first = false;
     }
-    warn!("{}", msg);
-    // out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
-    //     typ: MessageType::WARNING,
-    //     message: msg,
-    // }));
+    info!("{}", msg);
 }
 
 #[allow(dead_code)]
@@ -495,7 +492,7 @@ impl<O: Output> LsService<O> {
                             }
                         }
                         else {
-                            warn!(
+                            error!(
                                 "Server has not yet received an `initialize` request, ignoring {}", $method,
                             );
                         }
@@ -538,7 +535,7 @@ impl<O: Output> LsService<O> {
                             self.dispatcher.dispatch(request, ctx);
                         }
                         else {
-                            warn!(
+                            error!(
                                 "Server has not yet received an `initialize` request, cannot handle {}", $method,
                             );
                             self.output.failure_message(

--- a/src/vfs/mod.rs
+++ b/src/vfs/mod.rs
@@ -1,6 +1,6 @@
 //  © 2024 Intel Corporation
 //  SPDX-License-Identifier: Apache-2.0 and MIT
-use log::trace;
+use crate::logging::trace;
 
 use std::collections::HashMap;
 use std::cmp::Ordering;


### PR DESCRIPTION
Attempts & Testing of optimization of the device analysis

- **Use result to do cancellation-return instead of panic**
- **Box large enum variants**
- **Refine obj-to-contexts mapping error propagation**
- **Disable recursive cache**
- **Turn off caching**
- **Terminate message reader faster**
