### PR TITLE
Add functionality for goto-def on imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug in method-local variable lookups which caused inconsistent results when looking up variables within overridden methods
 - Fixed the reporting range for duplicate template names
 - Fixed a bug that caused intermittent failures around instantiated templates
+- Added the ability to goto-definition on imports to find the file that was imported
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed the reporting range for duplicate template names
 - Fixed a bug that caused intermittent failures around instantiated templates
 - Added the ability to goto-definition on imports to find the file that was imported
+- Allowed empty `-> ()` type specifier for method returns
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a bug that caused intermittent failures around instantiated templates
 - Added the ability to goto-definition on imports to find the file that was imported
 - Allowed empty `-> ()` type specifier for method returns
+- Replace provisional `explicit\_object\_decls` with `explicit\_object\_extensions`
 
 ## 0.9.18
 - Fixed a rare case where the DLS would crash when reporting device contexts

--- a/USAGE.md
+++ b/USAGE.md
@@ -84,6 +84,12 @@ instantiated.
 including direct instantiation sites (so this is a super-set of
 `goto-implementations`)
 
+### On Import Statements
+`goto-definition` on the target name of an import will open the file that was
+imported by that statement.
+
+Other operations on import statements do nothing.
+
 ## Relevant environment variables
 * `MAX_LOG_MESSAGE_LENGTH` When set, will truncate any outputted logs that are longer than the value. Defaults to 1000 bytes. Set to 0 to turn off truncation.
 

--- a/src/actions/analysis_queue.rs
+++ b/src/actions/analysis_queue.rs
@@ -484,7 +484,7 @@ impl IsolatedAnalysisJob {
 pub struct DeviceAnalysisJob {
     bases: Vec<TimestampedStorage<IsolatedAnalysis>>,
     root: IsolatedAnalysis,
-    import_sources: HashMap<Import, String>,
+    import_sources: HashMap<Import, CanonPath>,
     timestamp: SystemTime,
     report: ResultChannel,
     notify: channel::Sender<ServerToHandle>,
@@ -530,7 +530,7 @@ impl DeviceAnalysisJob {
                            });
         trace!("Missing bases are {:?}", missing.iter()
                .map(|a|a.as_str()).collect::<Vec<&str>>());
-        let mut import_sources: HashMap<Import, String> = HashMap::default();
+        let mut import_sources: HashMap<Import, CanonPath> = HashMap::default();
         trace!("Dependency map is {:?}", analysis.dependencies);
         trace!("Root is {:?}", root);
         for base in &bases {

--- a/src/actions/analysis_storage.rs
+++ b/src/actions/analysis_storage.rs
@@ -95,7 +95,7 @@ type AnalysisDirectDependencies =
 type AnalysisImportMap =
     HashMap<CanonPath,
             HashMap<Option<CanonPath>,
-                    HashMap<Import, String>>>;
+                    HashMap<Import, CanonPath>>>;
 
 // General note, all functions on AnalysisStorage assume that incoming PathBufs
 // are canonicalized
@@ -410,7 +410,7 @@ impl AnalysisStorage {
             for (dependency, import) in direct_dependencies {
                 context_dependencies.insert(dependency.clone());
                 context_import_maps.insert(
-                    import, dependency.as_str().to_string());
+                    import, dependency.clone());
 
                 // We need to request an analysis here, because this dependency
                 // might have just been found due to changed context

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -270,9 +270,10 @@ pub struct InitActionContext<O: Output> {
     pub direct_opens: Arc<Mutex<HashSet<CanonPath>>>,
     pub compilation_info: Arc<Mutex<CompilationInfoStorage>>,
 
-    // maps files to the paths of device contexts they should be
-    // analyzed under
+    // Track the device contexts which we currently use for analysis
     pub device_active_contexts: Arc<Mutex<ActiveDeviceContexts>>,
+    // Used to hold a-moment-ago active contexts, so we can check for when re-analysis or re-reporting is
+    // necessary
     previously_checked_contexts: Arc<Mutex<ActiveDeviceContexts>>,
 
     prev_changes: Arc<Mutex<HashMap<PathBuf, i32>>>,

--- a/src/actions/semantic_lookup.rs
+++ b/src/actions/semantic_lookup.rs
@@ -12,11 +12,12 @@ use crate::actions::analysis_storage::{AnalysisLookupError, AnalysisStorage};
 use crate::actions::{ContextDefinition, InitActionContext};
 use crate::analysis::scope::{ContextedSymbol, ContextKey};
 use crate::analysis::structure::objects::MaybeAbstract;
+use crate::analysis::structure::expressions::DMLString;
 use crate::analysis::symbols::DMLSymbolKind;
-use crate::analysis::{DeviceAnalysis, IsolatedAnalysis, LocationSpan, SymbolRef};
+use crate::analysis::{DeviceAnalysis, IsolatedAnalysis, LocationSpan, SymbolRef, ZeroRange};
 
 use crate::analysis::parsing::tree::{ZeroSpan, ZeroFilePosition};
-use crate::analysis::reference::{Reference, ReferenceKind};
+use crate::analysis::reference::{CodeReference, Reference, ReferenceKind};
 use crate::file_management::CanonPath;
 use crate::server::Output;
 
@@ -91,6 +92,7 @@ struct SemanticLookup<'t> {
     pub stored_symbols: DeviceSymbols<'t>,
     pub found_ref: Option<Reference>,
     pub analysis_info: AnalysisInfo<'t>,
+    pub targeted_files: Vec<CanonPath>,
     pub recognized_limitations: HashSet<DLSLimitation>,
 }
 
@@ -107,8 +109,8 @@ impl std::fmt::Debug for SemanticLookup<'_> {
 
 impl <'t> SemanticLookup<'t> {
     pub fn create_lookup(fp: &ZeroFilePosition,
-                        analysis_lock: &'t AnalysisStorage,
-                        ctx: &'t InitActionContext<impl Output>)
+                         analysis_lock: &'t AnalysisStorage,
+                         ctx: &'t InitActionContext<impl Output>)
         -> Result<Self, AnalysisLookupError> {
         let active_filter = ctx.device_active_contexts.lock().unwrap().clone();
         let analysis_info = analysises_at_fp(analysis_lock, fp, Some(&active_filter))?;
@@ -122,14 +124,20 @@ impl <'t> SemanticLookup<'t> {
 
         let mut stored_symbols = vec![];
         let mut found_ref = None;
+        let mut targeted_files = vec![];
         match lookup_result {
             SymbolsOrReference::Symbols(symbol_refs) => stored_symbols = symbol_refs,
             SymbolsOrReference::Reference(reference) => {
                 found_ref = Some(reference.clone());
-                stored_symbols = get_symbols_of_ref(
-                    &reference,
-                    &analysis_info,
-                    &mut recognized_limitations)
+                match reference {
+                    Reference::CodeReference(code_ref) => {
+                        stored_symbols = get_symbols_of_ref(&code_ref, &analysis_info, &mut recognized_limitations);
+                    },
+                    Reference::FileReference(file_ref) => {
+                        targeted_files = get_import_target_of(&file_ref, analysis_lock)
+                            .into_iter().cloned().collect();
+                    },
+                }
             },
             SymbolsOrReference::Nothing => (),
         }
@@ -139,6 +147,7 @@ impl <'t> SemanticLookup<'t> {
             found_ref, 
             analysis_info,
             recognized_limitations,
+            targeted_files,
         })
     }
 
@@ -194,7 +203,7 @@ fn get_refs_and_syms_at_fp<'t>(
         }
         return Ok(SymbolsOrReference::Symbols(syms));
     }
-    if let Some(refr) = ref_at_pos {
+    if let Some(refr) = ref_at_pos.and_then(|r|r.as_code_ref()) {
         if refr.reference_kind() == ReferenceKind::Type {
             relevant_limitations.insert(type_semantic_limitation());
         }
@@ -207,7 +216,7 @@ fn get_refs_and_syms_at_fp<'t>(
     }
 }
 
-fn get_symbols_of_ref<'t>(reference: &Reference,
+fn get_symbols_of_ref<'t>(reference: &CodeReference,
                           analysis_info: &AnalysisInfo<'t>,
                           relevant_limitations: &mut HashSet<DLSLimitation>)
     -> DeviceSymbols<'t> {
@@ -248,6 +257,22 @@ fn get_symbols_of_ref<'t>(reference: &Reference,
     }
 
     symbols
+}
+
+fn get_import_target_of<'t>(import_file_ref: &DMLString, analysis_info: &'t AnalysisStorage) -> Vec<&'t CanonPath> {
+    debug!("Mapping file reference {:?} to import target",import_file_ref);
+    let contexts_map = analysis_info.import_map.get(&CanonPath::from_path_buf(import_file_ref.span.path()).unwrap());
+    let all_imports = contexts_map.map(|file_imports|file_imports.values());
+    let mut result = vec![];
+    if let Some(maps) = all_imports {
+        for map in maps {
+            if let Some((_, resolved)) = map.iter()
+                .find(|(import_decl, _)|import_decl.name.val.as_str() == import_file_ref.val.as_str()) {
+                result.push(resolved);
+            }
+        }
+    }
+    result
 }
 
 fn context_symbol_at_pos<'t>(isolated_analysis: &'t IsolatedAnalysis, pos: &ZeroFilePosition) ->
@@ -382,10 +407,18 @@ pub fn definitions_at_fp(context: &InitActionContext<impl Output>,
         &analysis_lock,
         context)?;
     mem::swap(relevant_limitations, &mut semantic_lookup.recognized_limitations);
-    Ok(semantic_lookup.symbols()
-       .into_iter()
-       .flat_map(|s|definitions_of_symbol(&s, semantic_lookup.found_ref.as_ref()))
-       .collect())
+    if let Some(refr) = semantic_lookup.found_ref.as_ref().and_then(Reference::as_file_ref) {
+        let targets = get_import_target_of(refr, &analysis_lock);
+        Ok(targets.into_iter().map(|t|
+            ZeroSpan::from_range(ZeroRange::from_u32(0,0,0,0),
+                                 t.as_path().to_path_buf())
+        ).collect())
+    } else {
+        Ok(semantic_lookup.symbols()
+                .into_iter()
+                .flat_map(|s|definitions_of_symbol(&s, semantic_lookup.found_ref.as_ref()))
+                .collect())
+    }
 }
 
 pub fn declarations_at_fp(context: &InitActionContext<impl Output>,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -2338,7 +2338,7 @@ impl DeviceAnalysis {
                              unique_templates: &HashMap<
                                      &str, &ObjectDecl<Template>>,
                              files: &HashMap<&str, &TopLevel>,
-                             imp_map: &HashMap<Import, String>,
+                             imp_map: &HashMap<Import, CanonPath>,
                              errors: &mut Vec<DMLError>)
                              -> TemplateTraitInfo {
         info!("Rank templates");
@@ -2402,7 +2402,7 @@ impl DeviceAnalysis {
 
     pub fn new(root: IsolatedAnalysis,
                timed_bases: Vec<TimestampedStorage<IsolatedAnalysis>>,
-               imp_map: HashMap<Import, String>,
+               imp_map: HashMap<Import, CanonPath>,
                device_job_options: DeviceAnalysisJobOptions,
                status: AliveStatus)
                -> AnalysisProcessResult<DeviceAnalysis> {
@@ -2493,7 +2493,7 @@ impl DeviceAnalysis {
         // TODO: this is where we would do type resolution
         let mut container = StructureContainer::default();
         info!("Make device");
-        let device_key = make_device(root.path.as_str(), &root.toplevel,
+        let device_key = make_device(&root.path, &root.toplevel,
                                      &tt_info, imp_map, &mut container,
                                      &mut rank_maker, &mut errors).key;
         status.check_alive()?;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -31,7 +31,7 @@ use crate::actions::analysis_storage::{TimestampedStorage};
 use crate::actions::semantic_lookup::{DLSLimitation, isolated_template_limitation};
 use crate::analysis::symbols::{DMLSymbolKind, SimpleSymbol, StructureSymbol, SymbolContainer, SymbolMaker, SymbolSource};
 pub use crate::analysis::symbols::SymbolRef;
-use crate::analysis::reference::{GlobalReference, NodeRef, Reference, ReferenceKind, ReferenceVariant, VariableReference};
+use crate::analysis::reference::{GlobalReference, NodeRef, CodeReference, Reference, ReferenceKind, ReferenceVariant, VariableReference};
 use crate::analysis::scope::{Scope, SymbolContext,
                              ContextKey, ContextedSymbol};
 use crate::analysis::parsing::parser::{FileInfo, FileParser};
@@ -1549,7 +1549,7 @@ impl DeviceAnalysis {
     }
 
     fn handle_symbol_ref(symbol: &SymbolRef,
-                         reference: &Reference) {
+                         reference: &CodeReference) {
         let mut sym = symbol.lock().unwrap();
         sym.references.insert(*reference.loc_span());
         if sym.kind == DMLSymbolKind::Template && reference.extra_info.was_instantiation {
@@ -1602,48 +1602,50 @@ impl DeviceAnalysis {
             |mut local_reports, references|{
                 status.check_alive()?;
                 for reference in references {
-                    for object in &objects_of_scope {
-                        trace!("In {:?}, Matching {:?}", object, reference);
-                        let symbol_lookup = match &reference.variant {
-                            ReferenceVariant::Variable(var) => self.find_target_for_reference(
-                                Some(object),
-                                var,
-                                method_structure,
-                                reference_cache),
-                            ReferenceVariant::Global(glob) =>
-                                self.lookup_global_from_ref(glob),
-                        };
-
-                        match symbol_lookup.kind {
-                            ReferenceMatchKind::NotFound =>
-                            // TODO: report suggestions?
-                            // TODO: Uncomment reporting of errors here when
-                            // semantics are strong enough that they are rare
-                            // for correct devices
-                            // report.lock().unwrap().push(DMLError {
-                            //     span: reference.span().clone(),
-                            //     description: format!("Unknown reference {}",
-                            //                          reference.to_string()),
-                            //     related: vec![],
-                            // })
+                    // Non-coderef references will be resolved on-demand as requests are made
+                    if let Some(code_ref) = reference.as_code_ref() {
+                        for object in &objects_of_scope {
+                            trace!("In {:?}, Matching {:?}", object, reference);
+                            let symbol_lookup = match &code_ref.variant {
+                                ReferenceVariant::Variable(var) => self.find_target_for_reference(
+                                    Some(object),
+                                    var,
+                                    method_structure,
+                                    reference_cache),
+                                ReferenceVariant::Global(glob) =>
+                                    self.lookup_global_from_ref(glob),
+                            };
+                                
+                            match symbol_lookup.kind {
+                                ReferenceMatchKind::NotFound =>
+                                // TODO: report suggestions?
+                                // TODO: Uncomment reporting of errors here when
+                                // semantics are strong enough that they are rare
+                                // for correct devices
+                                // report.lock().unwrap().push(DMLError {
+                                //     span: reference.span().clone(),
+                                //     description: format!("Unknown reference {}",
+                                //                          reference.to_string()),
+                                //     related: vec![],
+                                // })
                                 (),
-                            // This maps symbols->references, this is later
-                            // used to create the inverse map
-                            // (not done here because of ownership issues)
+                                // This maps symbols->references, this is later
+                                // used to create the inverse map
+                                // (not done here because of ownership issues)
                             ReferenceMatchKind::Found =>
                                 for symbol in &symbol_lookup.references {
-                                    Self::handle_symbol_ref(symbol, reference);
+                                    Self::handle_symbol_ref(symbol, code_ref);
                                 },
                             ReferenceMatchKind::MismatchedFind =>
-                            //TODO: report mismatch,
+                                //TODO: report mismatch,
                                 (),
+                            }
+                            local_reports.extend(symbol_lookup.messages);
                         }
-                        local_reports.extend(symbol_lookup.messages);
                     }
                 }
                 Ok(local_reports)
-            })
-            .try_reduce(Vec::new, |mut vec1, vec2|{ vec1.extend(vec2); Ok(vec1) });
+        }).try_reduce(Vec::new, |mut vec1, vec2|{ vec1.extend(vec2); Ok(vec1) });
         report.extend(errs?);
         Ok(())
     }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1276,11 +1276,17 @@ impl DeviceAnalysis {
                     return Self::adjust_method_for_pos(defmeth, pos);
                 },
                 Some(DefaultCallReference::Ambiguous(defmeths)) => {
+                    // NOTE: We need to make results unique here, since diamond inheritance could cause us
+                    // to hit the same method twice when adjusting
+                    let mut res_make_unique = HashSet::new();
                     let mut res: Vec<_> = defmeths.iter()
                         .filter_map(|df|Self::adjust_method_for_pos(df, pos))
+                        .filter(|m|res_make_unique.insert(m.location()))
                         .collect();
                     if res.len() > 1 {
-                        internal_error!("Invariant broken: multiple methods contain the pos {:?} over method {:?}\nhit methods are: {:?}", pos, method, res);
+                        internal_error!("Invariant broken: multiple methods contain the pos {:?} over method {:?} at {:?}\nhit methods are: {:?}",
+                        pos, method.identity(), method.location(),
+                        res.iter().map(|m|format!("{:?} at {:?}", m.identity(), m.location())).collect::<Vec<_>>());
                     }
                     return res.pop();
                 },

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -573,6 +573,8 @@ impl ReferenceCache {
                       -> ReferenceCacheKey {
         let (object, refr) = key;
         let method_scope =
+            // contexts-to-obj will always give the most-overriding method, but our reference may actually be from a scope in an overridden method.
+            // So here we adjust and find the correct method
             if let Some(meth) = object.and_then(|o|o.as_shallow()).and_then(|s|s.variant.as_method()) {
                 let adjusted_meth = DeviceAnalysis::adjust_method_for_pos(meth, &refr.span().start_position())
                     .unwrap_or(meth);
@@ -1282,8 +1284,9 @@ impl DeviceAnalysis {
                     }
                     return res.pop();
                 },
+                // NOTE: we would like to report this as an internal error somewhere, but it turns out to be too
+                // costly to do so
                 _ => {
-                    internal_error!("Fell through recursive method noderef resolution for {:?} in method {:?}", pos, method);
                     return None;
                 }
             }
@@ -1299,12 +1302,14 @@ impl DeviceAnalysis {
                                             method_structure: &HashMap
                                             <ZeroSpan, RangeEntry>,
                                             ref_matches: &mut ReferenceMatches) {
-        // When resolving a noderef from an overridden method, meth here will be
-        // a bottom-most overriding method. So instead find the correct method
+        // Context-to-obj will always give the most-overriding method, but our reference may actually
+        // be from a scope in an overridden method. So here we adjust and find the correct method
         // by recursing to parent
         trace!("Resolving simple noderef {:?} in method {:?}", node, meth);
         let Some(adjusted_meth) = Self::adjust_method_for_pos(meth, &node.span().start_position())
-        else { return; };
+        else {
+            return;
+        };
         trace!("After adjusting, looking up in {:?}", adjusted_meth);
         match node.val.as_str() {
             "this" =>
@@ -1567,6 +1572,11 @@ impl DeviceAnalysis {
         let current_scope = scope_chain.last().unwrap();
         let context_chain: Vec<ContextKey> = scope_chain
             .iter().map(|s|s.create_context()).collect();
+        // NOTE: Awkwardly, this will _not_ give the correct override level
+        // for scopes that are overridden methods. So we will re-adjust
+        // the method reference at later points (when caching and looking up
+        // refs in method). This cannot be done at this level because we are
+        // dealing with a concrete object, and not a method reference.
         let objects_of_scope =
             if context_chain.len() == 1 {
                 // Must be device object
@@ -1600,7 +1610,7 @@ impl DeviceAnalysis {
                                 var,
                                 method_structure,
                                 reference_cache),
-                                ReferenceVariant::Global(glob) =>
+                            ReferenceVariant::Global(glob) =>
                                 self.lookup_global_from_ref(glob),
                         };
 

--- a/src/analysis/parsing/expression.rs
+++ b/src/analysis/parsing/expression.rs
@@ -10,7 +10,7 @@ use crate::analysis::parsing::tree::{AstObject, TreeElement,
                                      ZeroRange, ZeroSpan};
 use crate::analysis::parsing::types::CTypeDecl;
 use crate::analysis::parsing::misc::{objident_filter, SingleInitializer};
-use crate::analysis::reference::{Reference, ReferenceKind,
+use crate::analysis::reference::{CodeReference, Reference, ReferenceKind,
                                  MaybeIsNodeRef, NodeRef};
 use crate::analysis::FileSpec;
 use crate::analysis::structure::expressions::DMLString;
@@ -123,8 +123,8 @@ impl TreeElement for MemberLiteralContent {
         self.subs().into_iter()
             .for_each(|s|s.collect_references(accumulator, file));
         if let Some(refr) = self.maybe_noderef(file) {
-            accumulator.push(Reference::from_noderef(
-                refr, ReferenceKind::Variable));
+            accumulator.push(CodeReference::from_noderef(
+                refr, ReferenceKind::Variable).into());
         }
     }
 }
@@ -226,8 +226,8 @@ impl TreeElement for FunctionCallContent {
                       file: FileSpec<'a>) {
         self.default_references(accumulator, file);
         if let Some(noderef) = self.fun.maybe_noderef(file) {
-            accumulator.push(Reference::from_noderef(
-                noderef, ReferenceKind::Callable));
+            accumulator.push(CodeReference::from_noderef(
+                noderef, ReferenceKind::Callable).into());
         }
     }
     fn evaluate_rules(&self, acc: &mut Vec<DMLStyleError>, rules: &CurrentRules, aux: AuxParams) {
@@ -569,9 +569,9 @@ impl TreeElement for EachInContent {
                       accumulator: &mut Vec<Reference>,
                       file: FileSpec<'a>) {
         self.default_references(accumulator, file);
-        if let Some(refr) = Reference::global_from_token(
+        if let Some(refr) = CodeReference::global_from_token(
             &self.ident, file, ReferenceKind::Template) {
-            accumulator.push(refr);
+            accumulator.push(refr.into());
         }
     }
 }
@@ -782,8 +782,8 @@ impl TreeElement for ExpressionContent {
                       file: FileSpec<'a>) {
         self.default_references(accumulator, file);
         if let Some(refr) = self.maybe_noderef(file) {
-            accumulator.push(Reference::from_noderef(
-                refr, ReferenceKind::Variable));
+            accumulator.push(CodeReference::from_noderef(
+                refr, ReferenceKind::Variable).into());
         }
     }
 }

--- a/src/analysis/parsing/structure.rs
+++ b/src/analysis/parsing/structure.rs
@@ -10,7 +10,7 @@ use crate::analysis::parsing::misc::{CDecl, CDeclList, Initializer,
                                      ident_filter, objident_filter};
 use crate::analysis::parsing::statement::Statement;
 use crate::analysis::parsing::tree::{AstObject, LeafToken, TreeElement, TreeElements, ZeroRange};
-use crate::analysis::parsing::types::CTypeDecl;
+use crate::analysis::parsing::types::{CTypeDecl, CTypeDeclContent};
 use crate::analysis::parsing::parser::{doesnt_understand_tokens,
                                        FileParser, Parse, ParseContext,
                                        FileInfo};
@@ -305,15 +305,15 @@ fn parse_method(modifier: Option<LeafToken>,
             let mut paren_context = pre_statements_context.enter_context(
                 understands_rparen);
             let mut types = vec![];
-            // if return is declared, it cannot be empty
-                let mut end = false;
-            while !end {
+            let mut forced_end = false;
+            while paren_context.peek_kind(stream).is_some_and(|k|CTypeDeclContent::first_token_matcher(k))
+                  && !forced_end {
                 let typed = CTypeDecl::parse(&paren_context, stream, file_info);
                 let comma = match paren_context.peek_kind(stream) {
                     Some(TokenKind::Comma) =>
                         Some(paren_context.next_leaf(stream)),
                     _ => {
-                        end = true;
+                        forced_end = true;
                         None
                     },
                 };

--- a/src/analysis/parsing/structure.rs
+++ b/src/analysis/parsing/structure.rs
@@ -25,7 +25,7 @@ use crate::lint::rules::indentation::{IndentCodeBlockArgs,
     IndentParenExprArgs,
     IndentContinuationLineArgs};
 use crate::lint::{rules::CurrentRules, AuxParams, DMLStyleError};
-use crate::analysis::reference::{Reference, ReferenceKind};
+use crate::analysis::reference::{CodeReference, Reference, ReferenceKind};
 use crate::analysis::FileSpec;
 use crate::span::Range;
 use crate::vfs::TextFile;
@@ -631,9 +631,10 @@ impl TreeElement for Instantiation {
         };
 
         let refs = toks.into_iter()
-            .filter_map(|tok|Reference::global_from_token(
+            .filter_map(|tok|CodeReference::global_from_token(
                          tok, file, ReferenceKind::Template))
-            .map(|mut r|{r.extra_info.was_instantiation = true; r});
+            .map(|mut r|{r.extra_info.was_instantiation = true; r})
+            .map(Into::into);
         accumulator.extend(refs);
     }
 }
@@ -1265,6 +1266,13 @@ impl TreeElement for ImportContent {
     fn subs(&self) -> TreeElements<'_> {
         create_subs!(&self.import, &self.file, &self.semi)
     }
+    fn references<'a>(&self,
+                      accumulator: &mut Vec<Reference>,
+                      file: FileSpec<'a>) {
+        if let Some(reference) = Reference::file_ref_from_token(&self.file, file) {
+            accumulator.push(reference);
+        }
+    }
 }
 
 impl Parse<DMLObjectContent> for ImportContent {
@@ -1662,8 +1670,8 @@ impl TreeElement for InEachSpec {
         let references = match self {
             Self::One(tok) => vec![tok],
             Self::List(_, toks, _) => toks.iter().map(|(t, _)|t).collect(),
-        }.into_iter().filter_map(|tok|Reference::global_from_token(
-            tok, file, ReferenceKind::Template));
+        }.into_iter().filter_map(|tok|CodeReference::global_from_token(
+            tok, file, ReferenceKind::Template).map(Into::into));
         accumulator.extend(references);
     }
 }
@@ -1774,9 +1782,9 @@ impl TreeElement for DeviceContent {
     fn references<'a>(&self,
                       accumulator: &mut Vec<Reference>,
                       file: FileSpec<'a>) {
-        if let Some(refr) = Reference::global_from_token(
+        if let Some(refr) = CodeReference::global_from_token(
             &self.device, file, ReferenceKind::Template) {
-            accumulator.push(refr);
+            accumulator.push(refr.into());
         }
     }
 }

--- a/src/analysis/parsing/types.rs
+++ b/src/analysis/parsing/types.rs
@@ -684,6 +684,12 @@ impl Parse<CTypeDeclContent> for CTypeDecl {
     }
 }
 
+impl CTypeDeclContent {
+    pub fn first_token_matcher(token: TokenKind) -> bool {
+        token == TokenKind::Const || BaseType::first_token_matcher(token)
+    }
+}
+
 // TODO: Expand unit tests
 #[cfg(test)]
 mod test {

--- a/src/analysis/parsing/types.rs
+++ b/src/analysis/parsing/types.rs
@@ -14,7 +14,7 @@ use crate::analysis::parsing::tree::{AstObject, TreeElement, TreeElements,
                             LeafToken, ZeroRange};
 use crate::analysis::parsing::misc::{CDecl, ident_filter};
 use crate::analysis::parsing::expression::Expression;
-use crate::analysis::reference::{Reference, ReferenceKind};
+use crate::analysis::reference::{CodeReference, Reference, ReferenceKind};
 use crate::analysis::{FileSpec, LocalDMLError};
 use crate::vfs::TextFile;
 
@@ -489,9 +489,9 @@ impl TreeElement for BaseTypeContent {
                       file: FileSpec<'a>) {
         self.default_references(accumulator, file);
         if let BaseTypeContent::Ident(leaf) = self {
-            if let Some(refr) = Reference::global_from_token(
+            if let Some(refr) = CodeReference::global_from_token(
                 leaf, file, ReferenceKind::Type) {
-                accumulator.push(refr);
+                accumulator.push(refr.into());
             }
         }
     }

--- a/src/analysis/provisionals.rs
+++ b/src/analysis/provisionals.rs
@@ -15,7 +15,7 @@ use crate::analysis::FileSpec;
 pub enum Provisional {
     // TODO: implement the neccessary checks for explicit params
     ExplicitMethodDecls,
-    ExplicitObjectDecls,
+    ExplicitObjectExtensions,
     ExplicitParamDecls,
     SimicsUtilVect,
 }
@@ -71,7 +71,7 @@ mod test {
     #[test]
     fn test_provisionals_parsing() {
         for (s, p) in [
-            ("explicit_object_decls", Provisional::ExplicitObjectDecls),
+            ("explicit_object_extensions", Provisional::ExplicitObjectExtensions),
             ("explicit_param_decls", Provisional::ExplicitParamDecls),
             ("explicit_method_decls", Provisional::ExplicitMethodDecls),
             ("simics_util_vect", Provisional::SimicsUtilVect),

--- a/src/analysis/reference.rs
+++ b/src/analysis/reference.rs
@@ -116,9 +116,59 @@ pub struct ReferenceInfo {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Reference {
+pub struct CodeReference {
     pub variant: ReferenceVariant,
     pub extra_info: ReferenceInfo,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Reference {
+    CodeReference(CodeReference),
+    FileReference(DMLString),
+}
+
+impl Reference {
+    pub fn file_ref_from_token<'a>(token: &LeafToken, file: FileSpec<'a>) -> Option<Reference> {
+        DMLString::from_token(token, file).map(Reference::FileReference)
+    }
+}
+
+impl LocationSpan for Reference {
+    fn loc_span(&self) -> &ZeroSpan {
+        match self {
+            Reference::CodeReference(code_ref) => code_ref.loc_span(),
+            Reference::FileReference(import) => &import.span,
+        }
+    }
+}
+impl DeclarationSpan for Reference {
+    fn span(&self) -> &ZeroSpan {
+        match self {
+            Reference::CodeReference(code_ref) => code_ref.span(),
+            Reference::FileReference(import) => &import.span,
+        }
+    }
+}
+
+impl Reference  {
+    pub fn as_code_ref(&self) -> Option<&CodeReference> {
+        match self {
+            Reference::CodeReference(code_ref) => Some(code_ref),
+            _ => None,
+        }
+    }
+    pub fn as_file_ref(&self) -> Option<&DMLString> {
+        match self {
+            Reference::FileReference(file_ref) => Some(file_ref),
+            _ => None,
+        }
+    }
+}
+
+impl From<CodeReference> for Reference {
+    fn from(code_ref: CodeReference) -> Self {
+        Reference::CodeReference(code_ref)
+    }
 }
 
 // NOTE: The locationspan of a reference is the actual source range its
@@ -128,7 +178,7 @@ pub struct Reference {
 // a.f[3].r
 // would have the locationspan covering 'r'
 // and the declarationspan covering the full reference
-impl LocationSpan for Reference {
+impl LocationSpan for CodeReference {
     fn loc_span(&self) -> &ZeroSpan {
         match &self.variant {
             ReferenceVariant::Variable(var) => var.loc_span(),
@@ -136,7 +186,7 @@ impl LocationSpan for Reference {
         }
     }
 }
-impl DeclarationSpan for Reference {
+impl DeclarationSpan for CodeReference {
     fn span(&self) -> &ZeroSpan {
         match &self.variant {
             ReferenceVariant::Variable(var) => var.span(),
@@ -145,7 +195,7 @@ impl DeclarationSpan for Reference {
     }
 }
 
-impl std::fmt::Display for Reference {
+impl std::fmt::Display for CodeReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>)
            -> Result<(), std::fmt::Error> {
         match &self.variant {
@@ -155,7 +205,7 @@ impl std::fmt::Display for Reference {
     }
 }
 
-impl Reference {
+impl CodeReference {
     pub fn as_variable_ref(&self) -> Option<&VariableReference> {
         match &self.variant {
             ReferenceVariant::Variable(var) => Some(var),
@@ -163,8 +213,8 @@ impl Reference {
         }
     }
 
-    pub fn from_noderef(node: NodeRef, kind: ReferenceKind) -> Reference {
-        Reference {
+    pub fn from_noderef(node: NodeRef, kind: ReferenceKind) -> CodeReference {
+        CodeReference {
             variant: ReferenceVariant::Variable(VariableReference {
                 reference: node,
                 kind,
@@ -172,10 +222,11 @@ impl Reference {
             extra_info: ReferenceInfo::default(),
         }
     }
+
     pub fn global_from_string(name: String,
                               loc: ZeroSpan,
-                              kind: ReferenceKind) -> Reference {
-        Reference {
+                              kind: ReferenceKind) -> CodeReference {
+        CodeReference {
             variant: ReferenceVariant::Global(GlobalReference {
                 name,
                 loc,
@@ -186,9 +237,9 @@ impl Reference {
     }
     pub fn global_from_token<'a>(token: &LeafToken,
                                  file: FileSpec<'a>,
-                                 kind: ReferenceKind) -> Option<Reference> {
+                                 kind: ReferenceKind) -> Option<CodeReference> {
         token.read_leaf(file.file).map(
-            |string|Reference::global_from_string(
+            |string|CodeReference::global_from_string(
                 string,
                 ZeroSpan::from_range(token.range(),
                                      file.path),

--- a/src/analysis/structure/objects.rs
+++ b/src/analysis/structure/objects.rs
@@ -11,7 +11,7 @@ use crate::analysis::structure::types::{DMLType, deconstruct_cdecl, to_type};
 use crate::analysis::FileSpec;
 use crate::analysis::{LocalDMLError, DeclarationSpan, LocationSpan, DMLNamed,
                       Named};
-use crate::analysis::reference::{ReferenceKind, Reference,
+use crate::analysis::reference::{CodeReference, ReferenceKind, Reference,
                                  ReferenceContainer};
 use crate::analysis::symbols::{StructureSymbol, SimpleSymbol,
                                DMLSymbolKind,
@@ -1789,11 +1789,11 @@ fn to_composite_object<'a>(content: &structure::CompositeObjectContent,
     content.instantiation.references(&mut references, file);
     content.statements.references(&mut references, file);
     let kind = interpret_kind(&content.kind, file);
-    references.push(Reference::global_from_string(
+    references.push(CodeReference::global_from_string(
         kind.kind_name().to_string(),
         ZeroSpan::from_range(content.kind.range(),
                              file.path),
-        ReferenceKind::Template));
+        ReferenceKind::Template).into());
     Some(CompositeObject {
         kind,
         object,

--- a/src/analysis/structure/toplevel.rs
+++ b/src/analysis/structure/toplevel.rs
@@ -860,7 +860,7 @@ impl TopLevel {
             // for checking if a range is within a file (it will be if the
             // files match)
             filespan: ZeroSpan::from_range(ZeroRange::from_u32(
-                0,0,u32::MAX,u32::MAX), filespec.path),
+                0, u32::MAX, 0, u32::MAX), filespec.path),
             filename: filespec.path.to_path_buf(),
             version,
             device,

--- a/src/analysis/templating/objects.rs
+++ b/src/analysis/templating/objects.rs
@@ -35,6 +35,7 @@ use crate::analysis::templating::topology::{InEachStruct, InferiorVariant,
 use crate::analysis::templating::traits::{DMLTemplate, DMLTrait,
                                           get_impls, TraitMemberKind, TemplateTraitInfo};
 use crate::analysis::{LocationSpan, DeclarationSpan, combine_vec_of_decls};
+use crate::file_management::CanonPath;
 
 type InEachSpec = HashMap<String, Vec<(Vec<String>, (ZeroSpan, Arc<ObjectSpec>))>>;
 pub type StructureKey = DefaultKey;
@@ -110,7 +111,7 @@ fn create_spec<'t>(loc: ZeroSpan,
                    in_each_specs: &HashMap<&'t ObjectDecl<InEach>,
                                            Arc<ObjectSpec>>,
                    invalid_isimps: &HashMap<InferiorVariant<'t>, Vec<&'t str>>,
-                   imp_map: &HashMap<Import, String>,
+                   imp_map: &HashMap<Import, CanonPath>,
                    templates: &HashMap<String, Arc<DMLTemplate>>,
                    rank: &Rank,
                    _report: &mut Vec<DMLError>)
@@ -161,17 +162,15 @@ fn create_spec<'t>(loc: ZeroSpan,
     }
     let mut imports = HashMap::default();
     for inst in &spec.imports {
-        if let Some(invalid_names) = invalid_isimps.get(
-            &InferiorVariant::Import(inst)) {
+        if let Some(invalid_names) = invalid_isimps.get(&InferiorVariant::Import(inst)) {
             assert!(invalid_names.len() == 1);
         } else {
             imports.insert(
                 inst.clone(),
                 templates.get(
-                    imp_map.get(&inst.obj)
-                        .map_or_else(||inst.obj.imported_name(),
-                                     |s|s.as_str()))
-                    .cloned().unwrap());
+                    imp_map.get(&inst.obj).map_or_else(||inst.obj.imported_name(),
+                                                       |s|s.as_str())
+                ).cloned().unwrap());
         };
     }
 
@@ -231,7 +230,7 @@ pub fn create_objectspec<'t>(loc: ZeroSpan,
                              in_each_struct: &InEachStruct<'t>,
                              invalid_isimps: &HashMap<InferiorVariant<'t>,
                                                       Vec<&'t str>>,
-                             imp_map: &HashMap<Import, String>,
+                             imp_map: &HashMap<Import, CanonPath>,
                              templates: &HashMap<String, Arc<DMLTemplate>>,
                              rankmaker: &mut RankMaker,
                              report: &mut Vec<DMLError>) -> Arc<ObjectSpec> {
@@ -266,29 +265,29 @@ pub fn create_objectspec<'t>(loc: ZeroSpan,
                 imp_map, templates, &rank, report)
 }
 
-pub fn make_device<'t>(path: &str,
+pub fn make_device<'t>(path: &CanonPath,
                        toplevel: &TopLevel,
                        tt_info: &TemplateTraitInfo,
-                       mut imp_map: HashMap<Import, String>,
+                       mut imp_map: HashMap<Import, CanonPath>,
                        container: &'t mut StructureContainer,
                        rankmaker: &mut RankMaker,
                        report: &mut Vec<DMLError>) -> &'t DMLCompositeObject {
-    debug!("Creating a device for {}", path);
+    debug!("Creating a device for {:?}", path);
     // create the faux spec for the device toplevel, importing the device file
     // and specifying commandline parameters (TODO)
     let mut faux_stmts = StatementSpec::empty();
     let base_import = Import {
-        span: ZeroSpan::invalid(path),
+        span: ZeroSpan::invalid(path.clone()),
         name: DMLString {
             // We need to quote the path here, so as to adhere to all other
             // imports that are quoted
-            val: format!("\"{}\"", path),
-            span: ZeroSpan::invalid(path),
+            val: format!("\"{}\"", path.as_str()),
+            span: ZeroSpan::invalid(path.clone()),
         },
     };
     faux_stmts.imports.push(ObjectDecl::always(&base_import));
     // Sneak the faux statement into the imp_map
-    imp_map.insert(base_import, path.to_string());
+    imp_map.insert(base_import, path.clone());
     // Guaranteed, we do not dispatch device analysis on things
     // without device declarations
     let device_decl = toplevel.device.as_ref().unwrap();

--- a/src/analysis/templating/topology.rs
+++ b/src/analysis/templating/topology.rs
@@ -24,6 +24,7 @@ use crate::analysis::templating::objects::{create_objectspec};
 use crate::analysis::templating::traits::{TemplateTraitInfo,
                                           DMLTemplate,
                                           DMLTrait};
+use crate::file_management::CanonPath;
 
 lazy_static! {
     static ref RANKMAKER_ID: Mutex<u64> = Mutex::new(0);
@@ -168,7 +169,7 @@ pub fn create_templates_traits<'t>(
     template_specs: HashMap<&'t str, TemplateRef<'t>>,
     order: Vec<&'t str>,
     invalid_isimps: HashMap<InferiorVariant<'t>, Vec<&'t str>>,
-    imp_map: &'t HashMap<Import, String>,
+    imp_map: &'t HashMap<Import, CanonPath>,
     rank_struct: HashMap<&'t str, InEachStruct<'t>>,
     report: &mut Vec<DMLError>)
     -> TemplateTraitInfo {
@@ -256,7 +257,7 @@ pub struct DependencyInfo<'t> {
 }
 
 pub fn dependencies<'t>(statements: &'t StatementSpec,
-                        imp_map: &'t HashMap<Import, String>)
+                        imp_map: &'t HashMap<Import, CanonPath>)
                         -> DependencyInfo<'t> {
     let mut queue = vec![];
     let mut inferior = Inferiors::new();
@@ -313,8 +314,7 @@ pub fn dependencies<'t>(statements: &'t StatementSpec,
                 let name = imp_map.get(&imp.obj)
                     .map_or_else(||imp.obj.imported_name(), |s|s.as_str());
                 debug!("Mapped import {:?} to {:?}", imp.obj, name);
-                inferior.insert(name,
-                                InferiorVariant::Import(imp));
+                inferior.insert(name, InferiorVariant::Import(imp));
                 if imp.cond == ExistCondition::Always {
                     unconditional_references.insert(name);
                 }
@@ -480,7 +480,7 @@ type RankedTemplates<'t> = (HashMap<&'t str, TemplateRef<'t>>,
 pub fn rank_templates<'t>(real_templates: &HashMap<&'t str,
                                                    &'t ObjectDecl<Template>>,
                           files: &HashMap<&'t str, &'t TopLevel>,
-                          imp_map: &'t HashMap<Import, String>,
+                          imp_map: &'t HashMap<Import, CanonPath>,
                           report: &mut Vec<DMLError>)
                           -> RankedTemplates<'t>
 {
@@ -549,7 +549,7 @@ pub const BUILTIN_TEMPLATES: [&str; 47] = ["name",
 
 pub fn rank_templates_aux<'t>(mut templates: HashMap<&'t str,
                                                      TemplateRef<'t>>,
-                              imp_map: &'t HashMap<Import, String>,
+                              imp_map: &'t HashMap<Import, CanonPath>,
                               mut invalid_isimps: HashMap<InferiorVariant<'t>,
                                                           Vec<&'t str>>,
                               report: &mut Vec<DMLError>)
@@ -717,7 +717,7 @@ pub fn rank_templates_aux<'t>(mut templates: HashMap<&'t str,
                     match stmnt {
                         StatementSpecStatement::Import(imp) => {
                             if imp_map.get(&imp.obj).is_some_and(
-                                |iname|iname == templ2.get_name()) {
+                                |iname|iname.as_str() == templ2.get_name()) {
                                 is_import_cycle = true;
                                 is_or_imp_sites.push(imp.span());
                             }
@@ -778,7 +778,7 @@ pub fn rank_templates_aux<'t>(mut templates: HashMap<&'t str,
                         debug!("considering {:?}", stmnt);
 
                         // TODO: Look over if this is actually always safe
-                        if &imp_map[&imp.obj] == second {
+                        if &imp_map[&imp.obj].as_str() == second {
                             trace!("Set to disregard invalid 'import' {:?}",
                                    imp);
                             removed_one = true;


### PR DESCRIPTION
- **Improve error reports from failing method adjustment**
- **correct file-covering span**
- **Store canonpaths instead of strings for resolved imports**
- **Add the ability to goto-definition on an import**
